### PR TITLE
fix: update Python to 3.8 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,23 @@
 language: generic
-dist: trusty
+dist: xenial
 sudo: required
 
 matrix:
   include:
 
-  - language: python3
+  - language: python
     env:
     - JOBNAME=UNIT_TESTS
 
+    python:
+    - "3.8"
+
     install:
+    - python --version
     - sudo apt-get install -y libsqlcipher-dev
     - pip3 install -r requirements.txt
     - pip3 install dpytest==0.0.20
     - pip3 install discord.py==1.3.4
 
     script:
-    - python3 -m pytest tests
+    - python -m pytest tests


### PR DESCRIPTION
This PR addresses a problem with our Travis run where Python 3.7 is required. This PR updates Python in Travis to 3.8 as that is our development version used across our project.