### PR TITLE
Update ReactForRole

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 All notable changes to KoalaBot will be documented in this file.
-A lot these commands will only be available to administrators
+A lot of these commands will only be available to administrators
 
 ## [Unreleased]
 ### Twitch Alert
@@ -22,8 +22,23 @@ A lot these commands will only be available to administrators
 - `ignoreList` See a list of ignored users/channels in the server.
 
 - `unfilter <text>` Unfilter a word/string/regex of text that was previously filtered.
-- `unignore <mention>` Unignore a user/channel that was previously set as ingored
+- `unignore <mention>` Unignore a user/channel that was previously set as ignored
 
+### React For Role (RFR)
+##### Added
+- `rfr create` Create a new, blank rfr message. Default title is `React for Role`. Default description is `Roles below!`. 
+- `rfr delete` Delete an existing rfr message. 
+- `rfr addRequiredRole` Add a role required to react to/use rfr functionality. If no role is added, anyone can use rfr functionality.
+- `rfr removeRequiredRole` Removes a role from the group of roles someone requires to use rfr functionality 
+
+- `rfr edit addRoles` Add emoji/role combos to an existing rfr message. 
+- `rfr edit removeRoles` Remove emoji/role combos from an existing rfr message. 
+- `rfr edit description` Edit the description of an existing rfr message  
+- `rfr edit title` Edit the title of an existing rfr message.
+
+### Colour Role
+##### Changed
+- Fixed error that occasionally made custom colour roles be created in the wrong position, thus not showing correctly
 
 ## [0.1.8] - 18-10-2020
 ### Twitch Alert

--- a/KoalaBot.py
+++ b/KoalaBot.py
@@ -19,6 +19,7 @@ __status__ = "Development"  # "Prototype", "Development", or "Production"
 
 # Futures
 
+import logging
 # Built-in/Generic Imports
 import os
 
@@ -26,7 +27,6 @@ import os
 import discord
 from discord.ext import commands
 from dotenv import load_dotenv
-import logging
 
 # Own modules
 from utils.KoalaDBManager import KoalaDBManager as DBManager
@@ -47,6 +47,7 @@ DATABASE_PATH = "Koala.db"
 KOALA_GREEN = discord.Colour.from_rgb(0, 170, 110)
 PERMISSION_ERROR_TEXT = "This guild does not have this extension enabled, go to http://koalabot.uk, " \
                         "or use `k!help enableExt` to enable it"
+KOALA_IMAGE_URL = "https://cdn.discordapp.com/attachments/737280260541907015/752024535985029240/discord1.png"
 # Variables
 started = False
 client = commands.Bot(command_prefix=COMMAND_PREFIX)
@@ -54,6 +55,7 @@ database_manager = DBManager(DATABASE_PATH, DB_KEY)
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)-8s %(message)s')
 logger = logging.getLogger('discord')
 is_dpytest = False
+
 
 def is_owner(ctx):
     """
@@ -80,8 +82,10 @@ def is_admin(ctx):
     else:
         return ctx.author.guild_permissions.administrator or (str(ctx.author) == TEST_USER and is_dpytest)
 
+
 def is_dm_channel(ctx):
     return isinstance(ctx.channel, discord.channel.DMChannel)
+
 
 def load_all_cogs():
     """
@@ -138,7 +142,6 @@ async def on_command_error(ctx, error):
                                                      f"{str(error.retry_after)}s."))
     else:
         await ctx.send(embed=error_embed(description=error))
-
 if __name__ == "__main__":  # pragma: no cover
     os.system("title " + "KoalaBot")
     database_manager.create_base_tables()

--- a/cogs/ColourRole.py
+++ b/cogs/ColourRole.py
@@ -276,10 +276,10 @@ class ColourRole(commands.Cog):
             return 1
         if protected_role_list is None or len(protected_role_list) == 0:
             bot_member: discord.Member = guild.get_member(self.bot.user.id)
-            role_pos = sorted(bot_member.roles, key=lambda x: x.position)[0].position - 1
+            role_pos = sorted(bot_member.roles, key=lambda x: x.position)[-1].position - 1
         else:
             sorted_protected_role_list: List[discord.Role] = sorted(protected_role_list, key=lambda x: x.position)
-            role_pos = sorted_protected_role_list[0].position - 1
+            role_pos = sorted_protected_role_list[0].position
         if role_pos < 1:
             role_pos = 1
         return role_pos

--- a/cogs/ReactForRole.py
+++ b/cogs/ReactForRole.py
@@ -1,0 +1,1024 @@
+#!/usr/bin/env python
+
+"""
+KoalaBot Reaction Roles Code
+
+Author: Anan Venkatesh
+Commented using reStructuredText (reST)
+"""
+# Futures
+
+# Built-in/Generic Imports
+import re
+from typing import *
+
+import discord
+import emoji
+from discord.ext import commands
+
+# Own modules
+import KoalaBot
+from utils import KoalaDBManager, KoalaColours
+
+# Libs
+
+# Constants
+UNICODE_DISCORD_EMOJI_REGEXP: re.Pattern = re.compile("^:(\w+):$")
+CUSTOM_EMOJI_REGEXP: re.Pattern = re.compile("^<a?:(\w+):(\d+)>$")
+UNICODE_EMOJI_REGEXP: re.Pattern = re.compile(emoji.get_emoji_regexp())
+
+
+def rfr_is_enabled(ctx):
+    """
+    A command used to check if the guild has enabled rfr
+    e.g. @commands.check(rfr_is_enabled)
+    :param ctx: The context of the message
+    :return: True if enabled or test, False otherwise
+    """
+    try:
+        result = KoalaBot.check_guild_has_ext(ctx, "ReactForRole")
+    except PermissionError:
+        result = False
+
+    return result or (str(ctx.author) == KoalaBot.TEST_USER and KoalaBot.is_dpytest)
+
+
+class ReactForRole(commands.Cog):
+    """
+    A discord.py cog pertaining to a React for Role system to allow for automation in getting roles.
+    """
+
+    def __init__(self, bot: discord.Client):
+        self.bot = bot
+        KoalaBot.database_manager.create_base_tables()
+        KoalaBot.database_manager.insert_extension("ReactForRole", 0, True, True)
+        self.rfr_database_manager = ReactForRoleDBManager(KoalaBot.database_manager)
+        self.rfr_database_manager.create_tables()
+
+    @commands.group(name="rfr", aliases=["reactForRole", "react_for_role"])
+    async def react_for_role_group(self, ctx: commands.Context):
+        """
+        Group of commands for React for Role (rfr) functionality.
+        :param ctx: Context of the command
+        :return:
+        """
+        return
+
+    @commands.check(KoalaBot.is_admin)
+    @commands.check(rfr_is_enabled)
+    @react_for_role_group.command(name="createMsg", aliases=["create", "createMessage"])
+    async def rfr_create_message(self, ctx: commands.Context):
+        """
+        Creates a new rfr message in a channel of user's choice. User is prompted for (in this order)
+        channel ID/name/mention, message title, message description. Default title and description exist, which are
+        "React for Role" and "Roles below!" respectively. User requires admin perms to use.
+        :param ctx: Context of the command
+        :return:
+        """
+        await ctx.send(
+            "Okay, this will create a new react for role message in a channel of your choice."
+            "\nNote: The channel you specify will have its permissions edited to make it such that the @ everyone role "
+            "is unable to add new reactions to messages, they can only reaction with existing ones. Please keep this in"
+            " mind, or setup another channel entirely for this.")
+        channel_raw = await self.prompt_for_input(ctx, "channel ID, name or mention")
+        channel = None if (channel_raw == "") else await commands.TextChannelConverter().convert(ctx, channel_raw)
+        if not channel:
+            await ctx.send("Sorry, you didn't specify a valid channel ID, mention or name. Please restart the command.")
+        else:
+            del_msg = await channel.send(f"This should be a thing sent in the right channel.")
+            await ctx.send(
+                "Okay, what would you like the title of the react for role message to be? Please enter within 30"
+                " seconds.")
+            x = await self.wait_for_message(self.bot, ctx)
+            msg: discord.Message = x[0]
+            if not x[0]:
+                await ctx.send(
+                    "Okay, didn't receive a title. Do you actually want to continue? Send anything to confirm this.")
+                if not await self.is_user_alive(ctx):
+                    await ctx.send("Okay, didn't receive any confirmation. Cancelling command. Please restart.")
+                    await del_msg.delete()
+                    return
+                else:
+                    title: str = "React for Role"
+                    await ctx.send(
+                        "Okay, I'll just put in a default value for you, you can edit it later by using the k!rfr edit"
+                        " commands.")
+            else:
+                title: str = msg.content
+            await ctx.send(
+                f"Okay, the title of the message will be \"{title}\". What do you want the description to be?")
+            y = await self.wait_for_message(self.bot, ctx)
+            msg: discord.Message = y[0]
+            if not y[0]:
+                await ctx.send(
+                    "Okay, didn't receive a description. Do you actually want to continue? Send anything to confirm this.")
+                if not await self.is_user_alive(ctx):
+                    await ctx.send("Okay, didn't receive any confirmation. Cancelling command. Please restart.")
+                    await del_msg.delete()
+                    return
+                else:
+                    desc: str = "Roles below!"
+                    await ctx.send(
+                        "Okay, I'll just put in a default value for you, you can edit it later by using the k!rfr "
+                        "edit command.")
+            else:
+                desc: str = msg.content
+            await ctx.send(f"Okay, the description of the message will be \"{desc}\".\n Okay, "
+                           f"I'll create the react for role message now.")
+            embed: discord.Embed = discord.Embed(title=title, description=desc, colour=KoalaColours.KOALA_GREEN)
+            embed.set_footer(text="ReactForRole")
+            embed.set_thumbnail(
+                url="https://cdn.discordapp.com/attachments/737280260541907015/752024535985029240/discord1.png")
+            rfr_msg: discord.Message = await channel.send(embed=embed)
+            self.rfr_database_manager.add_rfr_message(ctx.guild.id, channel.id, rfr_msg.id)
+            await self.overwrite_channel_add_reaction_perms(ctx.guild, channel)
+            await ctx.send(
+                f"Your react for role message ID is {rfr_msg.id}, it's in {channel.mention}. You can use the other "
+                "k!rfr subcommands to change the message and add functionality as required.")
+            await del_msg.delete()
+
+    @commands.check(KoalaBot.is_admin)
+    @commands.check(rfr_is_enabled)
+    @react_for_role_group.command(name="deleteMsg", aliases=["delete", "deleteMessage"])
+    async def rfr_delete_message(self, ctx: commands.Context):
+        """
+        Deletes an existing rfr message. User is prompted for (in this order) channel ID/name/mention, message ID/URL,
+        Y/N confirmation. User needs admin perms to use.
+        :param ctx: Context of the command
+        :return:
+        """
+        await ctx.send(
+            "Okay, this will delete an existing react for role message. I'll need some details first though.")
+        msg, channel = await self.get_rfr_message_from_prompts(ctx)
+        await ctx.send("Please confirm that you would indeed like to delete the react for role message.")
+        if (await self.prompt_for_input(ctx, "Y/N")).lstrip().strip().upper() == "Y":
+            await ctx.send("Ok")
+            rfr_msg_row = self.rfr_database_manager.get_rfr_message(ctx.guild.id, channel.id, msg.id)
+            self.rfr_database_manager.remove_rfr_message_emoji_roles(rfr_msg_row[3])
+            self.rfr_database_manager.remove_rfr_message(ctx.guild.id, channel.id, msg.id)
+            await msg.delete()
+            await ctx.send("ReactForRole Message deleted")
+        else:
+            await ctx.send("Cancelled command.")
+
+    @react_for_role_group.group(name="edit", pass_context=True)
+    async def edit_group(self, ctx: commands.Context):
+        return
+
+    @commands.check(KoalaBot.is_admin)
+    @commands.check(rfr_is_enabled)
+    @edit_group.command(name="description", aliases=["desc"])
+    async def rfr_edit_description(self, ctx: commands.Context):
+        """
+        Edit the description of an existing rfr message. User is prompted for rfr message channel ID/name/mention,
+        rfr message ID/URL, new description, Y/N confirmation. User needs admin perms to use.
+        :param ctx: Context of the command
+        :return:
+        """
+        await ctx.send("Okay, this will edit the description of an existing react for role message. I'll need some "
+                       "details first though.")
+        msg, channel = await self.get_rfr_message_from_prompts(ctx)
+        embed = self.get_embed_from_message(msg)
+        await ctx.send(f"Your current description is {embed.description}. Please enter your new description.")
+        desc = await self.prompt_for_input(ctx, "description")
+        if desc != "":
+            await ctx.send(f"Your new description would be {desc}. Please confirm that you'd like this change.")
+            if (await self.prompt_for_input(ctx, "Y/N")).lstrip().strip().upper() == "Y":
+                embed.description = desc
+                await msg.edit(embed=embed)
+            else:
+                await ctx.send("Okay, cancelling command.")
+        else:
+            await ctx.send("Okay, cancelling command.")
+
+    @commands.check(KoalaBot.is_admin)
+    @commands.check(rfr_is_enabled)
+    @edit_group.command(name="title")
+    async def rfr_edit_title(self, ctx: commands.Context):
+        """
+        Edit the title of an existing rfr message. User is prompted for rfr message channel ID/name/mention,
+        rfr message ID/URL, new title, Y/N confirmation. User needs admin perms to use.
+        :param ctx: Context of the command
+        :return:
+        """
+        await ctx.send("Okay, this will edit the title of an existing react for role message. I'll need some details "
+                       "first though.")
+        msg, channel = await self.get_rfr_message_from_prompts(ctx)
+        embed = self.get_embed_from_message(msg)
+        await ctx.send(f"Your current title is {embed.title}. Please enter your new title.")
+        title = await self.prompt_for_input(ctx, "title")
+        if title != "":
+            await ctx.send(f"Your new title would be {title}. Please confirm that you'd like this change.")
+            if (await self.prompt_for_input(ctx, "Y/N")).lstrip().strip().upper() == "Y":
+                embed.title = title
+                await msg.edit(embed=embed)
+            else:
+                await ctx.send("Okay, cancelling command.")
+        else:
+            await ctx.send("Okay, cancelling command.")
+
+    @commands.check(KoalaBot.is_admin)
+    @commands.check(rfr_is_enabled)
+    @edit_group.command(name="addRoles")
+    async def rfr_add_roles_to_msg(self, ctx: commands.Context):
+        """
+        Adds roles to an existing rfr message. User is prompted for rfr message channel ID/name/mention, rfr message ID/
+        URL, emoji-role combos. Emoji-role combinations are to be given in
+        \\\n\"<emoji>, <role>\"
+        \\\n\"<emoji>, <role>\"
+        format. <role> can be the role ID, name or mention. `emoji` can be a custom emoji from the server, or a standard
+        unicode emoji. \\\nUser needs admin perms to use.
+        :param ctx: Context of the command.
+        :return:
+        """
+
+        await ctx.send(
+            "Okay. This will add roles to an already created react for role message. I'll need some details first "
+            "though.")
+        msg, channel = await self.get_rfr_message_from_prompts(ctx)
+        rfr_msg_row = self.rfr_database_manager.get_rfr_message(ctx.guild.id, channel.id, msg.id)
+
+        if not rfr_msg_row:
+            raise commands.CommandError("Message ID given is not that of a react for role message.")
+        await ctx.send("Okay, found the message you want to add to.")
+        remaining_slots = 20 - self.get_number_of_embed_fields(self.get_embed_from_message(msg))
+
+        if remaining_slots == 0:
+            await ctx.send(
+                "Unfortunately due to discord limitations that message cannot have any more reactions. If you want I "
+                "can create another message in the same channel though. Shall I do that?")
+
+            if (await self.prompt_for_input(ctx, "Y/N")).lstrip().strip().upper() == "Y":
+                await ctx.send(
+                    "Okay, I'll continue then. The new message will have the same title and description as the "
+                    "old one.")
+                old_embed = self.get_embed_from_message(msg)
+                embed: discord.Embed = discord.Embed(title=old_embed.title, description=old_embed.description)
+                embed.set_thumbnail(
+                    url=KoalaBot.KOALA_IMAGE_URL)
+                msg: discord.Message = await channel.send(embed=embed)
+                msg_id = msg.id
+                channel = msg.channel
+                self.rfr_database_manager.add_rfr_message(ctx.guild.id, channel.id, msg_id)
+                await ctx.send(f"Okay, the new message has ID {msg.id} and is in {msg.channel.mention}.")
+                rfr_msg_row = self.rfr_database_manager.get_rfr_message(ctx.guild.id, channel.id, msg_id)
+            else:
+                await ctx.send("Okay, I'll stop the command then.")
+                return
+
+        await ctx.send(
+            "Okay. Can I get the roles and emojis you want added to the message in a list with format: \n<emoji>,"
+            " <role>\n<emoji>, <role>\n<emoji>, <role>\netc. You can get a new line by using SHIFT + ENTER.")
+        await ctx.send(
+            f"Please note however that you've only got {remaining_slots} emoji-role combinations you can enter. I'll "
+            f"therefore only take the first {remaining_slots} you do. I'll wait for 3 minutes.")
+
+        input_role_emojis = (await self.wait_for_message(self.bot, ctx, 180))[0].content
+        emoji_role_list = await self.parse_emoji_and_role_input_str(ctx, input_role_emojis, remaining_slots)
+        rfr_embed = self.get_embed_from_message(msg)
+
+        for emoji_role in emoji_role_list:
+            discord_emoji = emoji_role[0]
+            role = emoji_role[1]
+
+            if discord_emoji in [x.name for x in rfr_embed.fields]:
+                await ctx.send("Found duplicate emoji in the message, I'm not accepting it.")
+            elif role in [x.value for x in rfr_embed.fields]:
+                await ctx.send("Found duplicate role in the message, I'm not accepting it.")
+            else:
+                if isinstance(discord_emoji, str):
+                    self.rfr_database_manager.add_rfr_message_emoji_role(rfr_msg_row[3], emoji.demojize(discord_emoji),
+                                                                         role.id)
+                else:
+                    self.rfr_database_manager.add_rfr_message_emoji_role(rfr_msg_row[3], str(discord_emoji), role.id)
+                rfr_embed.add_field(name=str(discord_emoji), value=role.mention, inline=False)
+                await msg.add_reaction(discord_emoji)
+
+                if isinstance(discord_emoji, str):
+                    KoalaBot.logger.info(
+                        f"ReactForRole: Added role ID {str(role.id)} to rfr message (channel, guild) {msg.id} "
+                        f"({str(channel.id)}, {str(ctx.guild.id)}) with emoji {discord_emoji}.")
+                else:
+                    KoalaBot.logger.info(
+                        f"ReactForRole: Added role ID {str(role.id)} to rfr message (channel, guild) {msg.id} "
+                        f"({str(channel.id)}, {str(ctx.guild.id)}) with emoji {discord_emoji.id}.")
+
+        await msg.edit(embed=rfr_embed)
+        await ctx.send("Okay, you should see the message with its new emojis now.")
+
+    @commands.check(KoalaBot.is_admin)
+    @commands.check(rfr_is_enabled)
+    @edit_group.command(name="removeRoles")
+    async def rfr_remove_roles_from_msg(self, ctx: commands.Context):
+        """
+        Removes roles from an existing rfr message. User is prompted for rfr message channel ID/name/mention, rfr message
+        ID/URL, emojis/roles to remove. User can specify either the emoji or the role for any emoji-role combination to
+        remove it, but it needs to be specified in the format below.
+        \\\n\"<emoji>/<role>\"
+        \\\n\"<emoji>/<role>\"
+        <role> can be the role ID, name or mention. emoji can be a custom emoji from the server, or a standard
+        unicode emoji. \\\nUser needs admin perms to use.
+        :param ctx: Context of the command.
+        :return:
+        """
+        await ctx.send(
+            "Okay, this will remove roles from an already existing react for role message. I'll need some details first"
+            " though.")
+        msg, channel = await self.get_rfr_message_from_prompts(ctx)
+        rfr_msg_row = self.rfr_database_manager.get_rfr_message(ctx.guild.id, channel.id, msg.id)
+
+        if not rfr_msg_row:
+            raise commands.CommandError("Message ID given is not that of a react for role message.")
+        await ctx.send("Okay, found the message you want to remove roles from.")
+        remaining_slots = self.get_number_of_embed_fields(self.get_embed_from_message(msg))
+
+        if remaining_slots == 0:
+            await ctx.send(
+                "Okay, it looks like you've already gotten rid of all roles from this message. Would you like me to del"
+                "ete the message too?")
+
+            if (await self.prompt_for_input(ctx, "Y/N")).lstrip().strip().upper() == "Y":
+                await ctx.send("Okay, deleting that message and removing it from the database.")
+                self.rfr_database_manager.remove_rfr_message(ctx.guild.id, channel.id, msg.id)
+                await msg.delete()
+                await ctx.send("Okay, deleted that react for role message. Have a nice day.")
+                return
+            else:
+                await ctx.send("Okay, I'll stop the command then.")
+                return
+        else:
+            await ctx.send(
+                "Okay, I'll take the info of the roles/emojis you want to remove now. Just enter it in a message "
+                "separated by new lines (SHIFT+ENTER). You can enter either the emojis used or the roles' ID/mention/"
+                "name, for each one.")
+
+            input_emoji_roles = (await self.wait_for_message(self.bot, ctx, 120))[0].content
+            wanted_removals = await self.parse_emoji_or_roles_input_str(ctx, input_emoji_roles)
+            rfr_embed: discord.Embed = self.get_embed_from_message(msg)
+            rfr_embed_fields = rfr_embed.fields
+            new_embed = discord.Embed(title=rfr_embed.title, description=rfr_embed.description,
+                                      colour=KoalaColours.KOALA_GREEN)
+            new_embed.set_thumbnail(
+                url="https://cdn.discordapp.com/attachments/737280260541907015/752024535985029240/discord1.png")
+            new_embed.set_footer(text="ReactForRole")
+            removed_field_indexes = []
+            reactions_to_remove: List[discord.Reaction] = []
+
+            for row in wanted_removals:
+                if isinstance(row, discord.Emoji) or isinstance(row, str):
+                    field_index = [x.name for x in rfr_embed_fields].index(str(row))
+                    if isinstance(row, str):
+                        self.rfr_database_manager.remove_rfr_message_emoji_role(rfr_msg_row[3],
+                                                                                emoji_raw=emoji.demojize(row))
+                    else:
+                        self.rfr_database_manager.remove_rfr_message_emoji_role(rfr_msg_row[3], emoji_raw=row)
+                else:
+                    # row is instance of role
+                    field_index = [x.value for x in rfr_embed_fields].index(row.mention)
+                    self.rfr_database_manager.remove_rfr_message_emoji_role(rfr_msg_row[3], role_id=row.id)
+
+                field = rfr_embed_fields[field_index]
+                removed_field_indexes.append(field_index)
+                reaction_emoji = await self.get_first_emoji_from_str(ctx, field.name)
+                reaction: discord.Reaction = [x for x in msg.reactions if str(x.emoji) == str(reaction_emoji)][0]
+                reactions_to_remove.append(reaction)
+
+            new_embed_fields = [field for field in rfr_embed_fields if
+                                rfr_embed_fields.index(field) not in removed_field_indexes]
+
+            for field in new_embed_fields:
+                new_embed.add_field(name=field.name, value=field.value, inline=False)
+
+            if self.get_number_of_embed_fields(new_embed) == 0:
+                await ctx.send("I see you've removed all emoji-role combinations from this react for role message. "
+                               "Would you like to delete this message?")
+
+                if (await self.prompt_for_input(ctx, "Y/N")).lstrip().strip().upper() == "Y":
+                    await ctx.send("Okay, I'll delete the message then.")
+                    self.rfr_database_manager.remove_rfr_message(ctx.guild.id, channel.id, msg.id)
+                    await msg.delete()
+                    return
+
+            for reaction in reactions_to_remove:
+                await reaction.clear()
+            await msg.edit(embed=new_embed)
+            await ctx.send("Okay, I've removed those options from the react for role message.")
+
+    @commands.Cog.listener()
+    async def on_raw_reaction_add(self, payload: discord.RawReactionActionEvent):
+        """
+        Event listener for adding a reaction. Doesn't need message to be in loaded cache.
+        Gives the user a role if they can get it, if not strips all their roles and removes their reacts.
+        :param payload: RawReactionActionEvent that happened
+        :return:
+        """
+        if not payload.member.bot:
+            rfr_message = self.rfr_database_manager.get_rfr_message(payload.guild_id, payload.channel_id,
+                                                                    payload.message_id)
+            if not rfr_message:
+                return
+            member_role = self.get_role_member_info(payload.emoji, rfr_message[3], payload.guild_id, payload.channel_id,
+                                                    payload.message_id, payload.user_id)
+            if not member_role:
+                # Remove the reaction
+                guild: discord.Guild = self.bot.get_guild(payload.guild_id)
+                channel: discord.TextChannel = guild.get_channel(payload.channel_id)
+                msg: discord.Message = await channel.fetch_message(payload.message_id)
+                await msg.clear_reaction(payload.emoji)
+            else:
+                if self.can_have_rfr_role(member_role[0]):
+                    await member_role[0].add_roles(member_role[1])
+                else:
+                    # Remove all rfr roles from member
+                    role_ids = self.rfr_database_manager.get_guild_rfr_roles(payload.guild_id)
+                    roles: List[discord.Role] = []
+                    for role_id in role_ids:
+                        role = discord.utils.get(member_role[0].guild.roles, id=role_id)
+                        if not role:
+                            continue
+                        roles.append(role)
+                    for role_to_remove in roles:
+                        await member_role[0].remove_roles(role_to_remove)
+                    # Remove members' reaction from all rfr messages in guild
+                    guild_rfr_messages = self.rfr_database_manager.get_guild_rfr_messages(payload.guild_id)
+                    if not guild_rfr_messages:
+                        KoalaBot.logger.error(
+                            f"ReactForRole: Guild RFR messages is empty on raw reaction add. Please check"
+                            f" guild ID {payload.guild_id}")
+
+                    else:
+                        for guild_rfr_message in guild_rfr_messages:
+                            guild: discord.Guild = member_role[0].guild
+                            channel: discord.TextChannel = guild.get_channel(guild_rfr_message[1])
+                            msg: discord.Message = await channel.fetch_message(guild_rfr_message[2])
+                            for x in msg.reactions:
+                                await x.remove(payload.member)
+
+    @commands.check(KoalaBot.is_admin)
+    @commands.check(rfr_is_enabled)
+    @react_for_role_group.command("addRequiredRole")
+    async def rfr_add_guild_required_role(self, ctx: commands.Context, role_str: str):
+        """
+        Adds a role to perms to use rfr functionality in a server, so you can specify that you need, e.g. "@Student" to
+        be able to use rfr functionality in the server. It's server-wide permissions handling however. By default anyone
+        can use rfr functionality in the server. User needs to have admin perms to use.
+        :param ctx: Context of the command
+        :param role_str: Role ID/name/mention
+        :return:
+        """
+        try:
+            role: discord.Role = await commands.RoleConverter().convert(ctx, role_str)
+            await ctx.send(f"Okay, I'll add {role.name} to the list of roles required for RFR usage on the server.")
+            self.rfr_database_manager.add_guild_rfr_required_role(ctx.guild.id, role.id)
+        except (commands.CommandError, commands.BadArgument):
+            await ctx.send("Found an issue with your provided argument, couldn't get an actual role. Please try again.")
+
+    @commands.check(KoalaBot.is_admin)
+    @commands.check(rfr_is_enabled)
+    @react_for_role_group.command("removeRequiredRole")
+    async def rfr_remove_guild_required_role(self, ctx: commands.Context, role_str: str):
+        """
+        Removes a role from perms for use of rfr functionality in a server, so you can specify that you need, e.g.
+        "@Student" to be able to use rfr functionality in the server. It's server-wide permissions handling however. By
+        default anyone can use rfr functionality in the server. User needs to have admin perms to use.
+        :param ctx: Context of the command
+        :param role_str: Role ID/name/mention
+        :return:
+        """
+        try:
+            role: discord.Role = await commands.RoleConverter().convert(ctx, role_str)
+            await ctx.send(
+                f"Okay, I'll remove {role.name} from the list of roles required for RFR usage on the server.")
+            self.rfr_database_manager.remove_guild_rfr_required_role(ctx.guild.id, role.id)
+        except (commands.CommandError, commands.BadArgument):
+            await ctx.send("Found an issue with your provided argument, couldn't get an actual role. Please try again.")
+
+    @commands.check(KoalaBot.is_admin)
+    @commands.check(rfr_is_enabled)
+    @react_for_role_group.command("listRequiredRoles")
+    async def rfr_list_guild_required_roles(self, ctx: commands.Context):
+        """
+        Lists the server-specific role permissions for using rfr functionality. If list is empty, any role can use rfr
+        functionality.
+        :param ctx: Context of the command.
+        :return:
+        """
+        role_ids = self.rfr_database_manager.get_guild_rfr_required_roles(ctx.guild.id)
+        msg_str = "You will need one of these roles to react to rfr messages on this server:\n"
+        for role_id in role_ids:
+
+            role: discord.Role = discord.utils.get(ctx.guild.roles, id=role_id)
+            if not role:
+                KoalaBot.logger.error(f"ReactForRole: Couldn't find role {role_id} in guild {ctx.guild.id}. Please "
+                                      f"check.")
+            else:
+                msg_str += f"{role.mention}\n"
+        await ctx.send(msg_str)
+
+    @commands.Cog.listener()
+    async def on_raw_reaction_remove(self, payload: discord.RawReactionActionEvent):
+        """
+        Event listener for removing a reaction. Doesn't need message to be in loaded cache. Removes the role from the
+        user if they have it, else does nothing.
+        :param payload: RawReactionActionEvent that happened.
+        :return:
+        """
+
+        rfr_message = self.rfr_database_manager.get_rfr_message(payload.guild_id, payload.channel_id,
+                                                                payload.message_id)
+        if not rfr_message:
+            return
+        member_role = self.get_role_member_info(payload.emoji, rfr_message[3], payload.guild_id, payload.channel_id,
+                                                payload.message_id, payload.user_id)
+        if not member_role or member_role[0].bot:
+            return
+        await member_role[0].remove_roles(member_role[1])
+
+    def can_have_rfr_role(self, member: discord.Member) -> bool:
+        """
+        check for rfr required roles, taking a member as argument
+        :param member: Member to check rfr perms for
+        :return: True if member has one of the required roles, or if there are no required roles. False otherwise
+        """
+        required_roles: List[int] = self.rfr_database_manager.get_guild_rfr_required_roles(member.guild.id)
+        if not required_roles or len(required_roles) == 0:
+            return True
+        return any(x in required_roles for x in [y.id for y in member.roles])
+
+    async def get_rfr_message_from_prompts(self, ctx: commands.Context) -> Tuple[discord.Message, discord.TextChannel]:
+        """
+        Gets an rfr message from prompting user, basically just calls prompt_for_input multiple times and gets value from
+        database based on input.
+        :param ctx: Context of the command this function is called in
+        :return: 2-Tuple of the message (if there is one, else None), and channel (if there is no message, else None).
+        """
+        channel_raw = await self.prompt_for_input(ctx, "Channel name, mention or ID")
+        channel = None if (channel_raw == "") else await commands.TextChannelConverter().convert(ctx, channel_raw)
+        if not channel:
+            raise commands.CommandError("Invalid channel given.")
+        msg_id_raw = await self.prompt_for_input(ctx, "react for role message ID")
+        msg_id = None if (msg_id_raw == "") else int(msg_id_raw)
+        if not msg_id:
+            raise commands.CommandError("Invalid Message ID given.")
+        msg = await channel.fetch_message(msg_id)
+        if not msg:
+            raise commands.CommandError("Invalid Message ID given.")
+        rfr_msg_row = self.rfr_database_manager.get_rfr_message(ctx.guild.id, channel.id, msg_id)
+        if not rfr_msg_row:
+            raise commands.CommandError("Message ID given is not that of a react for role message.")
+        return msg, channel
+
+    def get_role_member_info(self, emoji_reacted: discord.PartialEmoji, emoji_role_id: int, guild_id: int,
+                             channel_id: int, message_id: int, user_id: int) -> Optional[
+        Tuple[discord.Member, discord.Role]]:
+        """
+        Gets the role that should be added/removed to/from a Member on reacting to a known RFR message, and works out
+        which Member reacted.
+        :param emoji_reacted: Emoji of the raw reaction payload
+        :param emoji_role_id: DB key identifying specific RFR message in a Guild
+        :param guild_id: ID of the guild this event occurred in
+        :param channel_id: ID of the channel that the message was in
+        :param message_id: ID of the message that was reacted to
+        :param user_id: ID of the user who reacted
+        :return: Optional 2-Tuple (member, role) where member is the Member that reacted, and Role is the role that
+        should be given/taken away. If a role or member couldn't be found, returns None instead.
+        """
+        if emoji_reacted.is_unicode_emoji():
+            rep = emoji.demojize(emoji_reacted.name)
+            role_id = self.rfr_database_manager.get_rfr_reaction_role_by_emoji_str(emoji_role_id, rep)
+        elif emoji_reacted.is_custom_emoji():
+            rep = str(emoji_reacted)
+            role_id = self.rfr_database_manager.get_rfr_reaction_role_by_emoji_str(emoji_role_id, rep)
+        else:
+            KoalaBot.logger.error(
+                f"ReactForRole: Database error, guild {guild_id} has no entry in rfr database for message_id "
+                f"{message_id} in channel_id {channel_id}. Please check this.")
+            return
+        guild: discord.Guild = self.bot.get_guild(guild_id)
+        member: discord.Member = discord.utils.get(guild.members, id=user_id)
+        if not member:
+            return
+        if not role_id:
+            return
+        role: discord.Role = discord.utils.get(guild.roles, id=role_id)
+        return member, role
+
+    async def parse_emoji_and_role_input_str(self, ctx: commands.Context, input_str: str, remaining_slots: int) -> List[
+        Tuple[Union[discord.Emoji, str], discord.Role]]:
+        """
+        Parses input for the "k!rfr edit addRoles" commmand, in the
+        \n"<emoji>, <role>\n
+        <emoji>, <role>"
+        format.
+        :param ctx: context of the command that called this
+        :param input_str: input message content
+        :param remaining_slots: remaining slots left on the rfr embed referred to
+        :return: List of Emoji-Role pairs parsed from the input message.
+        """
+        rows = input_str.splitlines()
+        arr = []
+        for row in rows:
+            emoji_role = row.split(',')
+            if len(emoji_role) > 2:
+                raise commands.BadArgument("Too many categories/etc on one line.")
+            emoji: Union[discord.Emoji, str] = await self.get_first_emoji_from_str(ctx, emoji_role[0].strip())
+            if not emoji:
+                await ctx.send(f"Yeah, didn't find emoji for `{emoji_role[0]}`")
+                continue
+            role = await commands.RoleConverter().convert(ctx, emoji_role[1].lstrip().rstrip())
+            arr.append((emoji, role))
+            if len(arr) == remaining_slots:
+                return arr
+        return arr
+
+    async def parse_emoji_or_roles_input_str(self, ctx: commands.Context, input_str: str) -> List[
+        Union[discord.Emoji, str, discord.Role]]:
+        """
+        Parses input prompt for the "k!rfr edit removeRoles" command, to get a list of roles and emoji as the output.
+        Input format is
+        \n"<emoji>/<role>\n
+        <emoji>/<role>"
+        <role> can be the role ID, name or mention. emoji can be a custom emoji from the server, or a standard
+        unicode emoji.
+        :param ctx: Context of the command that called this
+        :param input_str: Input message content
+        :return: List of roles & emojis given in the input string.
+        """
+        rows = input_str.splitlines()
+        arr = []
+        for row in rows:
+            # Try and match it to an raw_emoji first
+            raw_emoji = await self.get_first_emoji_from_str(ctx, row.strip())
+            if not raw_emoji:
+                role = await commands.RoleConverter().convert(ctx, row.strip())
+                if not role:
+                    raise commands.BadArgument("Couldn't convert to a role or emoji.")
+                else:
+                    arr.append(role)
+            else:
+                arr.append(raw_emoji)
+        return arr
+
+    async def prompt_for_input(self, ctx: commands.Context, input_type: str) -> str:
+        """
+        Prompts a user for input in the form of a message. Has a forced timer of 60 seconds, because it basically just
+        deals with the rfr specific stuff. Returns whatever was input, or cancels the calling command
+        :param ctx: Context of the command that calls this
+        :param input_type: Name of whatever info is needed from a user, just so that the message looks nice/clear
+        :return: User's response's content
+        """
+        await ctx.send(f"Please enter {input_type} so I can progress further. I'll wait 60 seconds, don't worry.")
+        msg, channel = await self.wait_for_message(self.bot, ctx)
+        if not msg:
+            await channel.send("Okay, I'll cancel the command.")
+            return ""
+        else:
+            return msg.content
+
+    async def overwrite_channel_add_reaction_perms(self, guild: discord.Guild, channel: discord.TextChannel):
+        """
+        Overwrites a text channel's reaction perms so that nobody can add new reactions to any message sent in the
+        channel, only the bot, to make sure people don't mess with the system. Relies on roles tending not to be added/
+        removed constantly to keep performance satisfactory.
+        :param guild: Guild that the rfr message is in
+        :param channel: Channel that the rfr message is in
+        :return:
+        """
+        #  Get the @everyone role.
+        role: discord.Role = discord.utils.get(guild.roles, id=guild.id)
+        overwrite: discord.PermissionOverwrite = discord.PermissionOverwrite()
+        overwrite.update(add_reactions=False)
+        await channel.set_permissions(role, overwrite=overwrite)
+        bot_members: List[discord.Member] = [member for member in guild.members if member.bot]
+        for bot in bot_members:
+            await channel.set_permissions(bot, overwrite=None)
+
+    @staticmethod
+    async def wait_for_message(bot: discord.Client, ctx: commands.Context, timeout: float = 60.0) -> Tuple[
+        Optional[discord.Message], Optional[discord.TextChannel]]:
+        """
+        Wraps bot.wait_for with message event, checking that message author is the original context author. Has default
+        timeout of 60 seconds.
+        :param bot: Koala Bot client
+        :param ctx: Context of the original command
+        :param timeout: Time to wait before raising TimeoutError
+        :return: If a message (msg) was received, returns a tuple (msg, None). Else returns (None, ctx.channel)
+        """
+        try:
+            msg = await bot.wait_for('message', timeout=timeout, check=lambda message: message.author == ctx.author)
+        except (Exception, TypeError):
+            return None, ctx.channel
+        if not msg:
+            return msg, ctx.channel
+        return msg, None
+
+    async def is_user_alive(self, ctx: commands.Context):
+        """
+        Prompts user for message to check if they're alive. Any message will do. We hope they're alive anyways.
+        :param ctx: Context of the command that calls this
+        :return: True if message received, False otherwise.
+        """
+        msg = await self.wait_for_message(self.bot, ctx, 10)
+        if not msg[0]:
+            return False
+        return True
+
+    def get_embed_from_message(self, msg: discord.Message) -> Optional[discord.Embed]:
+        """
+        Gets the embed from a given message. Yup. That's it.
+        :param msg: Message to check
+        :return: Returns the embed if there is one. If there isn't returns None
+        """
+        if not msg:
+            return None
+        try:
+            embed = msg.embeds[0]
+            if not embed:
+                return None
+            return embed
+        except IndexError:
+            return None
+
+    def get_number_of_embed_fields(self, embed: discord.Embed) -> int:
+        """
+        Gets the number of fields in an embed.
+        :param embed: Embed to check
+        :return: Number of embed fields.
+        """
+        return len(embed.fields)
+
+    async def get_first_emoji_from_str(self, ctx: commands.Context, content: str) -> Optional[
+        Union[discord.Emoji, str]]:
+        """
+        Gets the first emoji in a string input, custom or not. Doesn't work with custom emojis the bot doesn't have
+        access to.
+        :param ctx: Context of the original command
+        :param content: Message content
+        :return: Emoji if there is a valid one. Otherwise None.
+        """
+        # First check for a custom discord emoji in the string
+        search_result = CUSTOM_EMOJI_REGEXP.search(content)
+        if not search_result:
+            # Check for a unicode emoji in the string
+            search_result = UNICODE_EMOJI_REGEXP.search(content)
+            if not search_result:
+                return None
+            return content
+        else:
+            emoji_str = search_result.group().strip()
+            try:
+                discord_emoji: discord.Emoji = await commands.EmojiConverter().convert(ctx, emoji_str)
+                return discord_emoji
+            except commands.CommandError:
+                await ctx.send(
+                    "An error occurred when trying to get the emoji. Please contact the bot developers for support.")
+                return None
+            except commands.BadArgument:
+                await ctx.send("Couldn't get the emoji you used - is it from this server or a server I'm in?")
+                return None
+
+
+class ReactForRoleDBManager:
+    """
+    A class for interacting with the KoalaBot ReactForRole database
+    """
+
+    def __init__(self, database_manager: KoalaDBManager):
+        self.database_manager: KoalaDBManager.KoalaDBManager = database_manager
+
+    def get_parent_database_manager(self):
+        """
+        Gets the parent database manager, i.e. the KoalaDBManager class this takes from
+        :return: parent database manager
+        """
+        return self.database_manager
+
+    def create_tables(self):
+        """
+        Creates all the tables associated with the React For Role extension
+        """
+        sql_create_guild_rfr_message_ids_table = """
+        CREATE TABLE IF NOT EXISTS GuildRFRMessages (
+        guild_id integer NOT NULL,
+        channel_id integer NOT NULL,
+        message_id integer NOT NULL,
+        emoji_role_id integer,
+        PRIMARY KEY (emoji_role_id),
+        FOREIGN KEY (guild_id) REFERENCES GuildExtensions(guild_id),
+        UNIQUE (guild_id, channel_id, message_id)
+        );
+        """
+        sql_create_rfr_message_emoji_roles_table = """
+        CREATE TABLE IF NOT EXISTS RFRMessageEmojiRoles (
+        emoji_role_id integer NOT NULL,
+        emoji_raw text NOT NULL,
+        role_id integer NOT NULL,
+        PRIMARY KEY (emoji_role_id, emoji_raw, role_id),
+        FOREIGN KEY (emoji_role_id) REFERENCES GuildRFRMessages(emoji_role_id),
+        UNIQUE (emoji_role_id, emoji_raw),
+        UNIQUE  (emoji_role_id, role_id)
+        );
+        """
+        sql_create_rfr_required_roles_table = """
+        CREATE TABLE IF NOT EXISTS GuildRFRRequiredRoles (
+        guild_id integer NOT NULL,
+        role_id integer NOT NULL,
+        PRIMARY KEY (guild_id, role_id),
+        FOREIGN KEY (guild_id) REFERENCES GuildExtensions(guild_id),
+        UNIQUE (guild_id, role_id)
+        );
+        """
+        self.database_manager.db_execute_commit(sql_create_guild_rfr_message_ids_table)
+        self.database_manager.db_execute_commit(sql_create_rfr_message_emoji_roles_table)
+        self.database_manager.db_execute_commit(sql_create_rfr_required_roles_table)
+
+    def add_rfr_message(self, guild_id: int, channel_id: int, message_id: int):
+        """
+        Add an rfr message to a guild. Table stores a unique emoji_role_id to prevent the same combination
+        appearing twice on a given message
+        :param guild_id: ID of the guild
+        :param channel_id: ID of the channel the rfr message is in
+        :param message_id: ID of the rfr message
+        :return:
+        """
+        self.database_manager.db_execute_commit(
+            f"""INSERT INTO GuildRFRMessages  (guild_id, channel_id, message_id) VALUES ({guild_id}, {channel_id}, {message_id});""")
+
+    def add_rfr_message_emoji_role(self, emoji_role_id: int, emoji_raw: str, role_id: int):
+        """
+        Add an emoji-role combination to an rfr message.
+        :param emoji_role_id: unique ID/key
+        :param emoji_raw: raw emoji representation in string format
+        :param role_id: ID of the role to give on react
+        :return:
+        """
+        self.database_manager.db_execute_commit(
+            f"""INSERT INTO RFRMessageEmojiRoles (emoji_role_id, emoji_raw, role_id) VALUES ({emoji_role_id}, \"{emoji_raw}\", {role_id});""")
+
+    def remove_rfr_message_emoji_role(self, emoji_role_id: int, emoji_raw: str = None, role_id: int = None):
+        """
+        Remove an emoji-role combination from the rfr message database. Uses the unique emoji_role_id to identify the
+        specific combo. Only removes one emoji-role combo
+        :param emoji_role_id: unique ID/key
+        :param emoji_raw: raw string representation of the emoji
+        :param role_id: ID of the role to give on react
+        :return:
+        """
+        if not emoji_raw:
+            self.database_manager.db_execute_commit(
+                f"""DELETE FROM RFRMessageEmojiRoles WHERE emoji_role_id = {emoji_role_id} AND role_id = {role_id};""")
+        else:
+            self.database_manager.db_execute_commit(
+                f"""DELETE FROM RFRMessageEmojiRoles WHERE emoji_role_id = {emoji_role_id} AND emoji_raw = \"{emoji_raw}\";""")
+
+    def remove_rfr_message_emoji_roles(self, emoji_role_id: int):
+        """
+        Removes all emoji-role combos with the same emoji_role_id i.e. on the same message.
+        :param emoji_role_id: unique ID/key
+        :return:
+        """
+        self.database_manager.db_execute_commit(
+            f"""DELETE FROM RFRMessageEmojiRoles WHERE emoji_role_id = {emoji_role_id};""")
+
+    def remove_rfr_message(self, guild_id: int, channel_id: int, message_id: int):
+        """
+        Removes an rfr message from the rfr message database, and also removes all emoji-role combos as part of it.
+        :param guild_id: Guild ID of the rfr message
+        :param channel_id: Channel ID of the rfr message
+        :param message_id: Message ID of the rfr message
+        :return:
+        """
+        emoji_role_id = self.get_rfr_message(guild_id, channel_id, message_id)
+        if not emoji_role_id:
+            return
+        else:
+            self.remove_rfr_message_emoji_roles(emoji_role_id[3])
+        self.database_manager.db_execute_commit(
+            f"""DELETE FROM GuildRFRMessages WHERE guild_id = {guild_id} AND channel_id = {channel_id} AND message_id = {message_id};""")
+
+    def get_rfr_message(self, guild_id: int, channel_id: int, message_id: int) -> Optional[Tuple[int, int, int, int]]:
+        """
+        Gets the unique rfr message that is specified by the guild ID, channel ID and message ID.
+        :param guild_id: Guild ID of the rfr message
+        :param channel_id: Channel ID of the rfr message
+        :param message_id: Message ID of the rfr message
+        :return: RFR message info of the specific message if found, otherwise None.
+        """
+        rows: List[Tuple[int, int, int, int]] = self.database_manager.db_execute_select(
+            f"""SELECT * FROM GuildRFRMessages WHERE guild_id = {guild_id} AND channel_id = {channel_id} AND message_id = {message_id};""")
+        if not rows:
+            return
+        return rows[0]
+
+    def get_guild_rfr_messages(self, guild_id: int):
+        """
+        Gets all rfr messages in a given guild, from the guild ID
+        :param guild_id: ID of the guild
+        :return: List of rfr messages in the guild.
+        """
+        rows: List[Tuple[int, int, int, int]] = self.database_manager.db_execute_select(
+            "SELECT * FROM GuildRFRMessages WHERE guild_id = ?;", args=[guild_id])
+        return rows
+
+    def get_guild_rfr_roles(self, guild_id: int) -> List[int]:
+        """
+        Returns all role IDs of roles given by RFR messages in a guild
+
+        :param guild_id: Guild ID to check in.
+        :return: Role IDs of RFR roles in a specific guild
+        """
+        rfr_messages: List[Tuple[int, int, int, int]] = self.database_manager.db_execute_select(
+            "SELECT * FROM GuildRFRMessages WHERE guild_id = ?;", guild_id)
+        if not rfr_messages:
+            return []
+        role_ids: List[int] = []
+        for rfr_message in rfr_messages:
+            emoji_role_id = rfr_message[3]
+            roles: List[Tuple[int, str, int]] = self.get_rfr_message_emoji_roles(emoji_role_id)
+            if not roles:
+                continue
+            ids: List[int] = [x[2] for x in roles]
+            role_ids.extend(ids)
+        return role_ids
+
+    def get_rfr_message_emoji_roles(self, emoji_role_id: int):
+        """
+        Returns all the emoji-role combinations on an rfr message
+
+        :param emoji_role_id: emoji-role combo identifier
+        :return: List of rows in the database if found, otherwise None
+        """
+        rows: List[Tuple[int, str, int]] = self.database_manager.db_execute_select(
+            f"""SELECT * FROM RFRMessageEmojiRoles WHERE emoji_role_id = {emoji_role_id};""")
+        if not rows:
+            return
+        return rows
+
+    def get_rfr_reaction_role(self, emoji_role_id: int, emoji_raw: str, role_id: int):
+        """
+        Returns a specific emoji-role combo on an rfr message
+
+        :param emoji_role_id: emoji-role combo identifier
+        :param emoji_raw: raw string representation of the emoji
+        :param role_id: role ID of the emoji-role combo
+        :return: Unique row corresponding to a specific emoji-role combo
+        """
+        rows: List[Tuple[int, str, int]] = self.database_manager.db_execute_select(
+            f"""SELECT * FROM RFRMessageEmojiRoles WHERE emoji_role_id = {emoji_role_id} AND emoji_raw = \"{emoji_raw}\" AND role_id = {role_id};""")
+        if not rows:
+            return
+        return rows[0]
+
+    def get_rfr_reaction_role_by_emoji_str(self, emoji_role_id: int, emoji_raw: str) -> Optional[int]:
+        """
+        Gets a role ID from the emoji_role_id and the emoji associated with that role in the emoji-role combo
+        :param emoji_role_id: emoji-role combo identifier
+        :param emoji_raw: raw string representation of the emoji
+        :return: role ID of the emoji-role combo
+        """
+        rows: Tuple[int, str, int] = self.database_manager.db_execute_select(
+            f"""SELECT * FROM RFRMessageEmojiRoles WHERE emoji_role_id = {emoji_role_id} AND emoji_raw = \"{emoji_raw}\";""")
+        if not rows:
+            return
+        return rows[0][2]
+
+    def add_guild_rfr_required_role(self, guild_id: int, role_id: int):
+        """
+        Adds a role to the list of roles required to use rfr functionality in a guild.
+        :param guild_id: guild ID
+        :param role_id: role ID
+        :return:
+        """
+        self.database_manager.db_execute_commit("INSERT INTO GuildRFRRequiredRoles VALUES (?,?);",
+                                                args=[guild_id, role_id])
+
+    def remove_guild_rfr_required_role(self, guild_id: int, role_id: int):
+        """
+        Removes a role from the list of roles required to use rfr functionality in a guild
+        :param guild_id: guild ID
+        :param role_id: role ID
+        :return:
+        """
+        self.database_manager.db_execute_commit("DELETE FROM GuildRFRRequiredRoles WHERE guild_id = ? AND role_id = ?",
+                                                args=[guild_id, role_id])
+
+    def get_guild_rfr_required_roles(self, guild_id) -> List[int]:
+        """
+        Gets the list of role IDs of roles required to use rfr functionality in a guild
+        :param guild_id: guild ID
+        :return: List of role IDs
+        """
+        rows = self.database_manager.db_execute_select("SELECT * FROM GuildRFRRequiredRoles WHERE guild_id = ?",
+                                                       args=[guild_id])
+        role_ids = [x[1] for x in rows]
+        if not role_ids:
+            return []
+        return role_ids
+
+
+def setup(bot: KoalaBot) -> None:
+    """
+    Load this cog to the KoalaBot.
+    :param bot: the bot client for KoalaBot
+    """
+    bot.add_cog(ReactForRole(bot))

--- a/production-requirements.txt
+++ b/production-requirements.txt
@@ -27,3 +27,4 @@ urllib3==1.25.10
 wcwidth==0.2.5
 websockets==8.1
 yarl==1.4.2
+emoji==0.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ chardet==3.0.4
 colorama==0.4.3
 discord.py==1.3.4
 dpytest==0.0.20
+emoji==0.6.0
 idna==2.10
 iniconfig==1.0.1
 mock==4.0.2
@@ -28,4 +29,3 @@ urllib3==1.25.10
 wcwidth==0.2.5
 websockets==8.1
 yarl==1.4.2
-

--- a/tests/test_ColourRole.py
+++ b/tests/test_ColourRole.py
@@ -285,8 +285,8 @@ async def test_calculate_custom_colour_role_position(num_roles):
     if lowest_protected == 2000000000 or lowest_protected == 1:
         expected = 1
     else:
-        expected = lowest_protected - 1
-    assert role_colour_cog.calculate_custom_colour_role_position(guild) == expected
+        expected = lowest_protected
+    assert role_colour_cog.calculate_custom_colour_role_position(guild) == expected, num_roles
 
 
 @pytest.mark.asyncio
@@ -321,7 +321,9 @@ async def test_get_guild_protected_colours(num_roles):
             assert result == colours
 
 
-@pytest.mark.parametrize("num_total, num_protected", [(0, 0), (1, 0), (2, 0), (1, 1), (2, 1), (5, 0), (5, 1), (5, 2)])
+@pytest.mark.parametrize("num_total, num_protected",
+                         [(0, 0), (1, 0), (2, 0), (1, 1), (2, 1), (5, 0), (5, 1), (5, 2), (50, 5), (50, 1), (50, 2),
+                          (50, 0)])
 @pytest.mark.asyncio
 async def test_list_protected_roles(num_total, num_protected):
     guild: discord.Guild = dpytest.get_config().guilds[0]
@@ -344,7 +346,9 @@ async def test_list_protected_roles(num_total, num_protected):
         assert r.mention in msg.content, r.mention + " " + msg.content
 
 
-@pytest.mark.parametrize("num_total, num_protected", [(0, 0), (1, 0), (2, 0), (1, 1), (2, 1), (5, 0), (5, 1), (5, 2)])
+@pytest.mark.parametrize("num_total, num_protected",
+                         [(0, 0), (1, 0), (2, 0), (1, 1), (2, 1), (5, 0), (5, 1), (5, 2), (50, 5), (50, 1), (50, 2),
+                          (50, 0)])
 @pytest.mark.asyncio
 async def test_list_custom_colour_allowed_roles(num_total, num_protected):
     guild: discord.Guild = dpytest.get_config().guilds[0]
@@ -411,7 +415,7 @@ async def test_is_valid_custom_colour(num_total, num_protected, test_colour):
     assert role_colour_cog.is_valid_custom_colour(test_colour, protected_colours)[0] != (lowest_colour_dist < 38.4)
 
 
-@pytest.mark.parametrize("num_members", [0, 1, 2, 5])
+@pytest.mark.parametrize("num_members", [0, 1, 2, 5, 50])
 @pytest.mark.asyncio
 async def test_prune_member_old_colour_roles(num_members):
     guild: discord.Guild = dpytest.get_config().guilds[0]
@@ -548,6 +552,7 @@ async def test_custom_colour_valid():
     colour_role = discord.utils.get(guild.roles, name=f"KoalaBot[0xE34A21]")
     dpytest.verify_message(
         f"Your new custom role colour is #E34A21, with the role {colour_role.mention}")
+    dpytest.verify_message(assert_nothing=True)
     assert "KoalaBot[0xE34A21]" in [role.name for role in guild.roles]
     assert "KoalaBot[0xE34A21]" in [role.name for role in member.roles]
 

--- a/tests/test_ReactForRole.py
+++ b/tests/test_ReactForRole.py
@@ -1,0 +1,820 @@
+#!/usr/bin/env python
+
+"""
+Testing KoalaBot ReactForRole Cog
+
+Commented using reStructuredText (reST)
+"""
+# Futures
+
+# Built-in/Generic Imports
+import random
+from typing import *
+
+# Libs
+import discord
+import discord.ext.test as dpytest
+import mock
+import pytest
+from discord.ext import commands
+from discord.ext.test import factories as dpyfactory
+
+# Own modules
+import KoalaBot
+from cogs import ReactForRole
+from cogs.ReactForRole import ReactForRoleDBManager
+from tests.utils import TestUtils as utils
+from tests.utils import TestUtilsCog
+from utils.KoalaDBManager import KoalaDBManager
+
+# Constants
+
+# Variables
+rfr_cog: ReactForRole.ReactForRole = None
+utils_cog: TestUtilsCog.TestUtilsCog = None
+DBManager = ReactForRoleDBManager(KoalaBot.database_manager)
+DBManager.create_tables()
+
+
+def setup_function():
+    """ setup any state specific to the execution of the given module."""
+    global rfr_cog
+    global utils_cog
+    bot: commands.Bot = commands.Bot(command_prefix=KoalaBot.COMMAND_PREFIX)
+    rfr_cog = ReactForRole.ReactForRole(bot)
+    utils_cog = TestUtilsCog.TestUtilsCog(bot)
+    bot.add_cog(rfr_cog)
+    bot.add_cog(utils_cog)
+    dpytest.configure(bot)
+    print("Tests starting")
+
+
+def independent_get_guild_rfr_message(guild_id=None, channel_id=None, message_id=None) -> List[
+    Tuple[int, int, int, int]]:
+    sql_select_str = "SELECT * FROM GuildRFRMessages WHERE "
+    if guild_id is not None:
+        sql_select_str += f"guild_id = {guild_id} AND "
+    if channel_id is not None:
+        sql_select_str += f"channel_id = {channel_id} AND "
+    if message_id is not None:
+        sql_select_str += f"message_id = {message_id} AND "
+    if not guild_id and not channel_id and not message_id:
+        sql_select_str = sql_select_str[:-7] + ";"
+    else:
+        sql_select_str = sql_select_str[:-5] + ";"
+    dbm: KoalaDBManager = KoalaBot.database_manager
+    rows = dbm.db_execute_select(sql_select_str)
+    if not rows:
+        return []
+    return rows
+
+
+def independent_get_rfr_message_emoji_role(emoji_role_id=None, emoji_raw=None, role_id=None) -> List[
+    Tuple[int, str, int]]:
+    sql_select_str = "SELECT * FROM RFRMessageEmojiRoles WHERE "
+    if emoji_role_id is not None:
+        sql_select_str += f"emoji_role_id = {emoji_role_id} AND "
+    if emoji_raw is not None:
+        sql_select_str += f"emoji_raw = '{emoji_raw}' AND "
+    if role_id is not None:
+        sql_select_str += f"role_id = {role_id} AND "
+    if not emoji_role_id and not emoji_raw and not role_id:
+        sql_select_str = sql_select_str[:-7] + ";"
+    else:
+        sql_select_str = sql_select_str[:-5] + ";"
+    dbm: KoalaDBManager = KoalaBot.database_manager
+    rows = dbm.db_execute_select(sql_select_str)
+    if not rows:
+        return []
+    return rows
+
+
+def independent_get_guild_rfr_required_role(guild_id=None, role_id=None) -> List[Tuple[int, int]]:
+    sql_select_str = "SELECT * FROM GuildRFRRequiredRoles WHERE "
+    if guild_id is not None:
+        sql_select_str += f"guild_id = {guild_id} AND "
+    if role_id is not None:
+        sql_select_str += f"role_id = {role_id} AND "
+    if not guild_id and not role_id:
+        sql_select_str = sql_select_str[:-7] + ";"
+    else:
+        sql_select_str = sql_select_str[:-5] + ";"
+    rows = DBManager.get_parent_database_manager().db_execute_select(sql_select_str)
+    if not rows:
+        return []
+    return rows
+
+
+def get_rfr_reaction_role_by_role_id(emoji_role_id: int, role_id: int) -> Optional[int]:
+    rows: Tuple[int, str, int] = DBManager.get_parent_database_manager().db_execute_select(
+        f"""SELECT * FROM RFRMessageEmojiRoles WHERE emoji_role_id = {emoji_role_id} AND role_id = {role_id};""")
+    if not rows:
+        return
+    return rows[0][2]
+
+
+@pytest.mark.asyncio
+async def test_rfr_db_functions_guild_rfr_messages():
+    guild: discord.Guild = dpytest.get_config().guilds[0]
+    channel: discord.TextChannel = dpytest.get_config().channels[0]
+    msg_id = dpyfactory.make_id()
+    # Test when no messages exist
+    expected_full_list: List[Tuple[int, int, int, int]] = []
+    assert independent_get_guild_rfr_message(
+        guild.id, channel.id, msg_id) == expected_full_list
+    assert independent_get_guild_rfr_message() == expected_full_list
+    # Test on adding first message, 1 message, 1 channel, 1 guild
+    DBManager.add_rfr_message(guild.id, channel.id, msg_id)
+    expected_full_list.append((guild.id, channel.id, msg_id, 1))
+    assert independent_get_guild_rfr_message() == expected_full_list
+    assert independent_get_guild_rfr_message(guild.id, channel.id, msg_id) == [
+        expected_full_list[0]]
+    # 2 guilds, 1 channel each, 2 messages
+    guild2: discord.Guild = dpytest.back.make_guild("TestGuild2")
+    channel2: discord.TextChannel = dpytest.back.make_text_channel(
+        "TestGuild2Channel1", guild2)
+    msg_id = dpyfactory.make_id()
+    dpytest.get_config().guilds.append(guild2)
+    DBManager.add_rfr_message(guild2.id, channel2.id, msg_id)
+    expected_full_list.append((guild2.id, channel2.id, msg_id, 2))
+    assert independent_get_guild_rfr_message(guild2.id, channel2.id, msg_id) == [
+        expected_full_list[1]]
+    assert independent_get_guild_rfr_message(guild2.id, channel2.id, msg_id)[0] == DBManager.get_rfr_message(guild2.id,
+                                                                                                             channel2.id,
+                                                                                                             msg_id)
+    assert independent_get_guild_rfr_message() == expected_full_list
+    # 1 guild, 2 channels with 1 message each
+    guild1channel2: discord.TextChannel = dpytest.back.make_text_channel(
+        "TestGuild1Channel2", guild)
+    msg_id = dpyfactory.make_id()
+    DBManager.add_rfr_message(guild.id, guild1channel2.id, msg_id)
+    expected_full_list.append((guild.id, guild1channel2.id, msg_id, 3))
+    assert independent_get_guild_rfr_message(
+        guild.id, guild1channel2.id, msg_id) == [expected_full_list[2]]
+    assert independent_get_guild_rfr_message(guild.id, guild1channel2.id, msg_id)[0] == DBManager.get_rfr_message(
+        guild.id, guild1channel2.id, msg_id)
+    assert independent_get_guild_rfr_message() == expected_full_list
+    assert independent_get_guild_rfr_message(
+        guild.id) == [expected_full_list[0], expected_full_list[2]]
+    # 1 guild, 1 channel, with 2 messages
+    msg_id = dpyfactory.make_id()
+    DBManager.add_rfr_message(guild.id, channel.id, msg_id)
+    expected_full_list.append((guild.id, channel.id, msg_id, 4))
+    assert independent_get_guild_rfr_message(guild.id, channel.id, msg_id) == [
+        expected_full_list[3]]
+    assert independent_get_guild_rfr_message(guild.id, channel.id, msg_id)[0] == DBManager.get_rfr_message(guild.id,
+                                                                                                           channel.id,
+                                                                                                           msg_id)
+    assert independent_get_guild_rfr_message() == expected_full_list
+    assert independent_get_guild_rfr_message(guild.id, channel.id) == [
+        expected_full_list[0], expected_full_list[3]]
+    # remove all messages
+    guild_rfr_messages = independent_get_guild_rfr_message()
+    for guild_rfr_message in guild_rfr_messages:
+        assert guild_rfr_message in guild_rfr_messages
+        DBManager.remove_rfr_message(
+            guild_rfr_message[0], guild_rfr_message[1], guild_rfr_message[2])
+        assert guild_rfr_message not in independent_get_guild_rfr_message()
+    assert independent_get_guild_rfr_message() == []
+
+
+@pytest.mark.asyncio
+async def test_rfr_db_functions_rfr_message_emoji_roles():
+    guild: discord.Guild = dpytest.get_config().guilds[0]
+    channel: discord.TextChannel = dpytest.get_config().channels[0]
+    msg_id = dpyfactory.make_id()
+    DBManager.add_rfr_message(guild.id, channel.id, msg_id)
+    guild_rfr_message = independent_get_guild_rfr_message()[0]
+    expected_full_list: List[Tuple[int, str, int]] = []
+    assert independent_get_rfr_message_emoji_role() == expected_full_list
+    # 1 unicode, 1 role
+    fake_emoji_1 = utils.fake_unicode_emoji()
+    fake_role_id_1 = dpyfactory.make_id()
+    expected_full_list.append((1, fake_emoji_1, fake_role_id_1))
+    DBManager.add_rfr_message_emoji_role(
+        guild_rfr_message[3], fake_emoji_1, fake_role_id_1)
+    assert independent_get_rfr_message_emoji_role() == expected_full_list
+    assert independent_get_rfr_message_emoji_role(1) == expected_full_list
+    assert independent_get_rfr_message_emoji_role(guild_rfr_message[3], fake_emoji_1,
+                                                  fake_role_id_1) == [DBManager.get_rfr_reaction_role(
+        guild_rfr_message[3], fake_emoji_1, fake_role_id_1)]
+    # 1 unicode, 1 custom, trying to get same role
+    fake_emoji_2 = utils.fake_custom_emoji_str_rep()
+    DBManager.add_rfr_message_emoji_role(
+        guild_rfr_message[3], fake_emoji_2, fake_role_id_1)
+    assert independent_get_rfr_message_emoji_role() == expected_full_list
+    assert independent_get_rfr_message_emoji_role(guild_rfr_message[3]) == DBManager.get_rfr_message_emoji_roles(
+        guild_rfr_message[3])
+    assert [DBManager.get_rfr_reaction_role(
+        guild_rfr_message[3], fake_emoji_2, fake_role_id_1)] == [None]
+    # 2 roles, with 1 emoji trying to give both roles
+    fake_role_id_2 = dpyfactory.make_id()
+    DBManager.add_rfr_message_emoji_role(
+        guild_rfr_message[3], fake_emoji_1, fake_role_id_2)
+    assert independent_get_rfr_message_emoji_role() == expected_full_list
+    assert independent_get_rfr_message_emoji_role(guild_rfr_message[3]) == DBManager.get_rfr_message_emoji_roles(
+        guild_rfr_message[3])
+    assert [DBManager.get_rfr_reaction_role(
+        guild_rfr_message[3], fake_emoji_1, fake_role_id_2)] == [None]
+
+    # 2 roles, 2 emojis, 1 message. split between them
+    fake_emoji_2 = utils.fake_custom_emoji_str_rep()
+    fake_role_id_2 = dpyfactory.make_id()
+    expected_full_list.append((1, fake_emoji_2, fake_role_id_2))
+    DBManager.add_rfr_message_emoji_role(*expected_full_list[1])
+    assert independent_get_rfr_message_emoji_role() == expected_full_list
+    assert independent_get_rfr_message_emoji_role(
+        1, fake_emoji_1) == [(1, fake_emoji_1, fake_role_id_1)]
+    assert independent_get_rfr_message_emoji_role(
+        1, fake_emoji_2) == [(1, fake_emoji_2, fake_role_id_2)]
+    assert independent_get_rfr_message_emoji_role(1, fake_emoji_1)[0][
+               2] == DBManager.get_rfr_reaction_role_by_emoji_str(1,
+                                                                  fake_emoji_1)
+    assert independent_get_rfr_message_emoji_role(
+        1) == DBManager.get_rfr_message_emoji_roles(1)
+    assert independent_get_rfr_message_emoji_role(1, role_id=fake_role_id_2)[0][
+               2] == get_rfr_reaction_role_by_role_id(emoji_role_id=1, role_id=fake_role_id_2)
+
+    # 2 roles 2 emojis, 2 messages. duplicated messages
+    msg2_id = dpyfactory.make_id()
+    DBManager.add_rfr_message(guild.id, channel.id, msg2_id)
+    assert independent_get_guild_rfr_message(
+    ) == [guild_rfr_message, (guild.id, channel.id, msg2_id, 2)]
+    guild_rfr_message_2 = independent_get_guild_rfr_message()[1]
+    DBManager.add_rfr_message_emoji_role(
+        guild_rfr_message_2[3], fake_emoji_1, fake_role_id_1)
+    DBManager.add_rfr_message_emoji_role(
+        guild_rfr_message_2[3], fake_emoji_2, fake_role_id_2)
+    expected_full_list.extend([(guild_rfr_message_2[3], fake_emoji_1, fake_role_id_1),
+                               (guild_rfr_message_2[3], fake_emoji_2, fake_role_id_2)])
+    assert independent_get_rfr_message_emoji_role() == expected_full_list
+    assert independent_get_rfr_message_emoji_role(
+        2) == DBManager.get_rfr_message_emoji_roles(2)
+    assert independent_get_rfr_message_emoji_role(
+        1) == DBManager.get_rfr_message_emoji_roles(1)
+
+    # 2 roles 2 emojis 2 messages. Swapped
+    msg3_id = dpyfactory.make_id()
+    DBManager.add_rfr_message(guild.id, channel.id, msg3_id)
+    assert independent_get_guild_rfr_message() == [guild_rfr_message, (guild.id, channel.id, msg2_id, 2),
+                                                   (guild.id, channel.id, msg3_id, 3)]
+    guild_rfr_message_3 = independent_get_guild_rfr_message()[2]
+    DBManager.add_rfr_message_emoji_role(
+        guild_rfr_message_3[3], fake_emoji_1, fake_role_id_2)
+    DBManager.add_rfr_message_emoji_role(
+        guild_rfr_message_3[3], fake_emoji_2, fake_role_id_1)
+    expected_full_list.extend([(guild_rfr_message_3[3], fake_emoji_1, fake_role_id_2),
+                               (guild_rfr_message_3[3], fake_emoji_2, fake_role_id_1)])
+    assert independent_get_rfr_message_emoji_role() == expected_full_list
+    assert independent_get_rfr_message_emoji_role(
+        3) == DBManager.get_rfr_message_emoji_roles(3)
+    assert [x[2] for x in independent_get_rfr_message_emoji_role(emoji_raw=fake_emoji_1)] == [
+        DBManager.get_rfr_reaction_role_by_emoji_str(1, fake_emoji_1),
+        DBManager.get_rfr_reaction_role_by_emoji_str(2, fake_emoji_1),
+        DBManager.get_rfr_reaction_role_by_emoji_str(3, fake_emoji_1)]
+    assert [x[2] for x in independent_get_rfr_message_emoji_role(emoji_raw=fake_emoji_2)] == [
+        DBManager.get_rfr_reaction_role_by_emoji_str(1, fake_emoji_2),
+        DBManager.get_rfr_reaction_role_by_emoji_str(2, fake_emoji_2),
+        DBManager.get_rfr_reaction_role_by_emoji_str(3, fake_emoji_2)]
+    # test deletion works from rfr message
+    rfr_message_emoji_roles = independent_get_rfr_message_emoji_role(3)
+    DBManager.remove_rfr_message(guild.id, channel.id, msg3_id)
+    for row in rfr_message_emoji_roles:
+        assert row not in independent_get_rfr_message_emoji_role(
+        ), independent_get_guild_rfr_message()
+    # test deleting just emoji role combos
+    rfr_message_emoji_roles = independent_get_rfr_message_emoji_role(2)
+    DBManager.remove_rfr_message_emoji_roles(2)
+    for row in rfr_message_emoji_roles:
+        assert row not in independent_get_rfr_message_emoji_role(
+        ), independent_get_guild_rfr_message()
+    # test deleteing specific
+    rfr_message_emoji_roles = independent_get_rfr_message_emoji_role(1)
+    DBManager.remove_rfr_message_emoji_role(
+        1, emoji_raw=rfr_message_emoji_roles[0][1])
+    assert (rfr_message_emoji_roles[0][0], rfr_message_emoji_roles[0][1],
+            rfr_message_emoji_roles[0][2]) not in independent_get_rfr_message_emoji_role()
+    DBManager.remove_rfr_message_emoji_role(
+        1, role_id=rfr_message_emoji_roles[1][2])
+    assert (rfr_message_emoji_roles[1][0], rfr_message_emoji_roles[1][1],
+            rfr_message_emoji_roles[1][2]) not in independent_get_rfr_message_emoji_role()
+
+
+@pytest.mark.asyncio
+async def test_rfr_db_functions_guild_rfr_required_roles():
+    guild: discord.Guild = dpytest.get_config().guilds[0]
+    roles = []
+    for i in range(50):
+        role: discord.Role = utils.fake_guild_role(guild)
+        roles.append(role)
+        DBManager.add_guild_rfr_required_role(guild.id, role.id)
+        assert [x[1] for x in independent_get_guild_rfr_required_role()] == [x.id for x in roles], i
+        assert [x[1] for x in independent_get_guild_rfr_required_role()] == DBManager.get_guild_rfr_required_roles(
+            guild.id), i
+
+    while len(roles) > 0:
+        role: discord.Role = roles.pop()
+        DBManager.remove_guild_rfr_required_role(guild.id, role.id)
+        assert [x[1] for x in independent_get_guild_rfr_required_role()] == [x.id for x in roles], len(roles)
+        assert [x[1] for x in independent_get_guild_rfr_required_role()] == DBManager.get_guild_rfr_required_roles(
+            guild.id), len(roles)
+
+
+@pytest.mark.asyncio
+async def test_get_rfr_message_from_prompts():
+    config: dpytest.RunnerConfig = dpytest.get_config()
+    guild: discord.Guild = config.guilds[0]
+    channel: discord.TextChannel = guild.channels[0]
+    member: discord.Member = config.members[0]
+    msg: discord.Message = dpytest.back.make_message(".", member, channel)
+    channel_id = msg.channel.id
+    msg_id = msg.id
+
+    await dpytest.message(KoalaBot.COMMAND_PREFIX + "store_ctx")
+    ctx: commands.Context = utils_cog.get_last_ctx()
+    with mock.patch('cogs.ReactForRole.ReactForRole.prompt_for_input',
+                    side_effect=[str(channel_id), str(546542131)]) as mock_input:
+        with mock.patch('discord.abc.Messageable.fetch_message', mock.AsyncMock(return_value=None)):
+            with pytest.raises(commands.CommandError) as exc:
+                await rfr_cog.get_rfr_message_from_prompts(ctx)
+            assert str(exc.value) == "Invalid Message ID given."
+    with mock.patch('cogs.ReactForRole.ReactForRole.prompt_for_input',
+                    side_effect=[str(channel_id), str(msg_id)]) as mock_input:
+        with mock.patch('discord.abc.Messageable.fetch_message', mock.AsyncMock(return_value=msg)):
+            with pytest.raises(commands.CommandError) as exc:
+                await rfr_cog.get_rfr_message_from_prompts(ctx)
+            assert str(
+                exc.value) == "Message ID given is not that of a react for role message."
+    DBManager.add_rfr_message(msg.guild.id, channel_id, msg_id)
+    with mock.patch('cogs.ReactForRole.ReactForRole.prompt_for_input',
+                    side_effect=[str(channel_id), str(msg_id)]) as mock_input:
+        with mock.patch('discord.abc.Messageable.fetch_message', mock.AsyncMock(return_value=msg)):
+            rfr_msg, rfr_msg_channel = await rfr_cog.get_rfr_message_from_prompts(ctx)
+            assert rfr_msg.id == msg.id
+            assert rfr_msg_channel.id == channel_id
+
+
+# TODO Actually implement the test.
+@pytest.mark.parametrize("num_rows", [0, 1, 2, 20, 100, 250])
+@pytest.mark.asyncio
+async def test_parse_emoji_and_role_input_str(num_rows):
+    config: dpytest.RunnerConfig = dpytest.get_config()
+    guild: discord.Guild = config.guilds[0]
+    await dpytest.message(KoalaBot.COMMAND_PREFIX + "store_ctx")
+    ctx: commands.Context = utils_cog.get_last_ctx()
+    for i in range(5):
+        input_str = ""
+        expected_emoji_list = []
+        expected_role_list = []
+        for j in range(num_rows):
+            fake_emoji = random.choice(
+                [utils.fake_guild_emoji(guild), utils.fake_unicode_emoji()])
+            expected_emoji_list.append(str(fake_emoji))
+            if isinstance(fake_emoji, discord.Emoji):
+                fake_emoji_str = random.choice(
+                    [fake_emoji.id, fake_emoji.name])
+            else:
+                fake_emoji_str = fake_emoji
+            fake_role = utils.fake_guild_role(guild)
+            expected_role_list.append(fake_role)
+            fake_role_str = random.choice([fake_role.id, fake_role.name,
+                                           fake_role.mention])
+            input_str += f"{fake_emoji_str}, {fake_role_str}\n\r"
+        emoji_roles_list = await rfr_cog.parse_emoji_and_role_input_str(ctx, input_str, 20)
+        for emoji_role in emoji_roles_list:
+            assert str(emoji_role[0]) == str(
+                expected_emoji_list[emoji_roles_list.index(emoji_role)])
+            assert emoji_role[1] == expected_role_list[emoji_roles_list.index(
+                emoji_role)]
+
+
+@pytest.mark.skip("dpytest has non-implemented functionality for construction of guild custom emojis")
+@pytest.mark.parametrize("num_rows", [0, 1, 2, 20])
+@pytest.mark.asyncio
+async def test_parse_emoji_or_roles_input_str(num_rows):
+    import emoji
+    image = discord.File("utils/discord.png", filename="discord.png")
+    config: dpytest.RunnerConfig = dpytest.get_config()
+    guild: discord.Guild = config.guilds[0]
+    await dpytest.message(KoalaBot.COMMAND_PREFIX + "store_ctx")
+    ctx: commands.Context = utils_cog.get_last_ctx()
+    input_str = ""
+    expected_list = []
+    for j in range(num_rows):
+        if random.choice([True, False]):
+            if random.choice([True, False]):
+                fake_emoji = utils.fake_emoji_unicode()
+                input_str += fake_emoji + "\n\r"
+                expected_list.append(fake_emoji)
+                print(f"Unicode emoji {j} in test {num_rows}: {emoji.emojize(fake_emoji)}")
+            else:
+                fake_emoji_name = utils.fake_custom_emoji_name_str()
+                fake_emoji = await guild.create_custom_emoji(name=fake_emoji_name, image=utils.random_image())
+                expected_list.append(fake_emoji)
+                input_str += str(fake_emoji) + "\n\r"
+                print(f"Custom emoji {j} in test {num_rows}: {str(fake_emoji)}")
+        else:
+            role_name = utils.fake_custom_emoji_name_str()
+            await guild.create_role(name=role_name, mentionable=True, hoist=True)
+            fake_role: discord.Role = discord.utils.get(guild.roles, name=role_name)
+            expected_list.append(fake_role)
+            role_str = str(random.choice([fake_role.name, fake_role.id, fake_role.mention]))
+            input_str += role_str + "\n\r"
+            print(f"Role {j} in test {num_rows}: {fake_role}")
+
+    print(f"Test {num_rows} input_str")
+    print(input_str)
+    result_list = await rfr_cog.parse_emoji_or_roles_input_str(ctx, input_str)
+    for k in range(len(expected_list)):
+        assert str(expected_list[k]) == str(result_list[k])
+
+
+@pytest.mark.parametrize("msg_content", [None, "", "something", " "])
+@pytest.mark.asyncio
+async def test_prompt_for_input(msg_content):
+    config: dpytest.RunnerConfig = dpytest.get_config()
+    author: discord.Member = config.members[0]
+    guild: discord.Guild = config.guilds[0]
+    channel: discord.TextChannel = guild.text_channels[0]
+    await dpytest.message(KoalaBot.COMMAND_PREFIX + "store_ctx")
+    ctx: commands.Context = utils_cog.get_last_ctx()
+    await dpytest.empty_queue()
+    if not msg_content:
+        with mock.patch('cogs.ReactForRole.ReactForRole.wait_for_message',
+                        mock.AsyncMock(return_value=(None, channel))):
+            result = await rfr_cog.prompt_for_input(ctx, "test")
+            dpytest.verify_message("Please enter test so I can progress further. I'll wait 60 seconds, don't worry.")
+            dpytest.verify_message("Okay, I'll cancel the command.")
+            assert not result
+    else:
+        msg: discord.Message = dpytest.back.make_message(content=msg_content, author=author, channel=channel)
+        with mock.patch('cogs.ReactForRole.ReactForRole.wait_for_message', mock.AsyncMock(return_value=(msg, None))):
+            result = await rfr_cog.prompt_for_input(ctx, "test")
+            dpytest.verify_message("Please enter test so I can progress further. I'll wait 60 seconds, don't worry.")
+            assert result == msg_content
+
+
+@pytest.mark.asyncio
+async def test_overwrite_channel_add_reaction_perms():
+    config: dpytest.RunnerConfig = dpytest.get_config()
+    guild: discord.Guild = config.guilds[0]
+    channel: discord.TextChannel = guild.text_channels[0]
+    with mock.patch('discord.ext.test.backend.FakeHttp.edit_channel_permissions') as mock_edit_channel_perms:
+        for i in range(15):
+            await guild.create_role(name=f"TestRole{i}", permissions=discord.Permissions.all())
+        role: discord.Role = discord.utils.get(guild.roles, id=guild.id)
+        await rfr_cog.overwrite_channel_add_reaction_perms(guild, channel)
+        mock_edit_channel_perms.assert_called_once_with(channel.id, role.id, 0, 64, 'role', reason=None)
+
+
+@pytest.mark.parametrize("msg_content", [" ", "something"])
+@pytest.mark.asyncio
+async def test_wait_for_message_not_none(msg_content):
+    await dpytest.message(KoalaBot.COMMAND_PREFIX + "store_ctx")
+    ctx = utils_cog.get_last_ctx()
+    config: dpytest.RunnerConfig = dpytest.get_config()
+    bot: discord.Client = config.client
+    import threading
+    t2 = threading.Timer(interval=0.1, function=dpytest.message, args=(msg_content))
+    t2.start()
+    fut = rfr_cog.wait_for_message(bot, ctx)
+    t2.join()
+    assert fut, dpytest.sent_queue
+
+
+@pytest.mark.asyncio
+async def test_wait_for_message_none():
+    await dpytest.message(KoalaBot.COMMAND_PREFIX + "store_ctx")
+    ctx: commands.Context = utils_cog.get_last_ctx()
+    config: dpytest.RunnerConfig = dpytest.get_config()
+    bot: discord.Client = config.client
+    msg, channel = await rfr_cog.wait_for_message(bot, ctx, 0.2)
+    assert not msg
+    assert channel == ctx.channel
+
+
+@pytest.mark.asyncio
+async def test_is_user_alive():
+    await dpytest.message(KoalaBot.COMMAND_PREFIX + "store_ctx")
+    ctx: commands.Context = utils_cog.get_last_ctx()
+    with mock.patch('cogs.ReactForRole.ReactForRole.wait_for_message',
+                    mock.AsyncMock(return_value=(None, ctx.channel))):
+        alive: bool = await rfr_cog.is_user_alive(ctx)
+        assert not alive
+    with mock.patch('cogs.ReactForRole.ReactForRole.wait_for_message', mock.AsyncMock(return_value=('a', None))):
+        alive: bool = await rfr_cog.is_user_alive(ctx)
+        assert alive
+
+
+@pytest.mark.asyncio
+async def test_get_embed_from_message():
+    config: dpytest.RunnerConfig = dpytest.get_config()
+    author: discord.Member = config.members[0]
+    guild: discord.Guild = config.guilds[0]
+    channel: discord.TextChannel = guild.text_channels[0]
+    test_embed_dict: dict = {'title': 'title', 'description': 'descr', 'type': 'rich', 'url': 'https://www.google.com'}
+    bot: discord.Client = config.client
+    await bot.http.send_message(channel.id, '', embed=test_embed_dict)
+    sent_msg: discord.Message = await dpytest.sent_queue.get()
+    msg_mock: discord.Message = dpytest.back.make_message('a', author, channel)
+    result = rfr_cog.get_embed_from_message(None)
+    assert result is None
+    result = rfr_cog.get_embed_from_message(msg_mock)
+    assert result is None
+    result = rfr_cog.get_embed_from_message(sent_msg)
+    assert dpytest.embed_eq(result, sent_msg.embeds[0])
+
+
+@pytest.mark.asyncio
+async def test_get_number_of_embed_fields():
+    config: dpytest.RunnerConfig = dpytest.get_config()
+    guild: discord.Guild = config.guilds[0]
+    channel: discord.TextChannel = guild.text_channels[0]
+    test_embed_dict: dict = {'title': 'title', 'description': 'descr', 'type': 'rich', 'url': 'https://www.google.com'}
+    bot: discord.Client = config.client
+    await bot.http.send_message(channel.id, '', embed=test_embed_dict)
+    sent_msg: discord.Message = await dpytest.sent_queue.get()
+    test_embed: discord.Embed = sent_msg.embeds[0]
+    num_fields = 0
+    for i in range(20):
+        test_embed.add_field(name=f'field{i}', value=f'num{i}')
+        num_fields += 1
+        assert rfr_cog.get_number_of_embed_fields(test_embed) == num_fields
+
+
+@pytest.mark.skip('dpytest currently has non-implemented functionality for construction of guild custom emojis')
+@pytest.mark.asyncio
+async def test_get_first_emoji_from_str():
+    await dpytest.message(KoalaBot.COMMAND_PREFIX + "store_ctx")
+    ctx: commands.Context = utils_cog.get_last_ctx()
+    config: dpytest.RunnerConfig = dpytest.get_config()
+    guild: discord.Guild = config.guilds[0]
+    guild_emoji = utils.fake_guild_emoji(guild)
+    guild_emoji = discord.Emoji(guild=guild, state=None,
+                                data={'name': "AAA", 'image': None, 'id': dpyfactory.make_id(),
+                                      'require_colons': True, 'managed': False})
+    guild._state.store_emoji(guild=guild,
+                             data={'name': "AAA", 'image': None, 'id': dpyfactory.make_id(),
+                                   'require_colons': True, 'managed': False})
+    assert guild_emoji in guild.emojis
+
+    author: discord.Member = config.members[0]
+    channel: discord.TextChannel = guild.text_channels[0]
+    msg: discord.Message = dpytest.back.make_message(str(guild_emoji), author, channel)
+    result = await rfr_cog.get_first_emoji_from_str(ctx, msg.content)
+    print(result)
+    assert isinstance(result, discord.Emoji), msg.content
+    assert guild_emoji == result
+
+
+@pytest.mark.asyncio
+async def test_rfr_create_message():
+    config: dpytest.RunnerConfig = dpytest.get_config()
+    guild: discord.Guild = config.guilds[0]
+    channel: discord.TextChannel = guild.text_channels[0]
+    embed_channel: discord.TextChannel = dpytest.back.make_text_channel('EmbedChannel', guild)
+    author: discord.Member = config.members[0]
+    from utils import KoalaColours
+    test_embed = discord.Embed(title="React for Role", description="Roles below!", colour=KoalaColours.KOALA_GREEN)
+    test_embed.set_footer(text="ReactForRole")
+    test_embed.set_thumbnail(
+        url=KoalaBot.KOALA_IMAGE_URL)
+    with mock.patch('cogs.ReactForRole.ReactForRole.prompt_for_input',
+                    mock.AsyncMock(return_value=embed_channel.mention)):
+        with mock.patch('cogs.ReactForRole.ReactForRole.wait_for_message',
+                        mock.AsyncMock(return_value=(None, channel))):
+            with mock.patch('cogs.ReactForRole.ReactForRole.is_user_alive', mock.AsyncMock(return_value=True)):
+                with mock.patch(
+                        'discord.ext.test.backend.FakeHttp.edit_channel_permissions') as mock_edit_channel_perms:
+                    with mock.patch('discord.Message.delete') as mock_delete:
+                        await dpytest.message(KoalaBot.COMMAND_PREFIX + "rfr createMessage")
+                        mock_edit_channel_perms.assert_called_once()
+                        dpytest.verify_message(
+                            "Okay, this will create a new react for role message in a channel of your choice."
+                            "\nNote: The channel you specify will have its permissions edited to make it such that the "
+                            "@ everyone role is unable to add new reactions to messages, they can only reaction with "
+                            "existing ones. Please keep this in mind, or setup another channel entirely for this.")
+                        dpytest.verify_message("This should be a thing sent in the right channel.")
+                        dpytest.verify_message(
+                            "Okay, what would you like the title of the react for role message to be? Please enter within 30 seconds.")
+                        dpytest.verify_message(
+                            "Okay, didn't receive a title. Do you actually want to continue? Send anything to confirm this.")
+                        dpytest.verify_message(
+                            "Okay, I'll just put in a default value for you, you can edit it later by using the k!rfr edit commands.")
+                        dpytest.verify_message(
+                            "Okay, the title of the message will be \"React for Role\". What do you want the description to be?")
+                        dpytest.verify_message(
+                            "Okay, didn't receive a description. Do you actually want to continue? Send anything to confirm this.")
+                        dpytest.verify_message(
+                            "Okay, I'll just put in a default value for you, you can edit it later by using the k!rfr edit command.")
+                        dpytest.verify_message(
+                            "Okay, the description of the message will be \"Roles below!\".\n Okay, I'll create the react for role message now.")
+                        dpytest.verify_embed()
+                        msg = dpytest.sent_queue.get_nowait()
+                        assert "You can use the other k!rfr subcommands to change the message and add functionality as required." in msg.content
+                        mock_delete.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_rfr_delete_message():
+    config: dpytest.RunnerConfig = dpytest.get_config()
+    guild: discord.Guild = config.guilds[0]
+    channel: discord.TextChannel = guild.text_channels[0]
+    message: discord.Message = await dpytest.message("rfr")
+    msg_id = message.id
+    DBManager.add_rfr_message(guild.id, channel.id, msg_id)
+    await dpytest.empty_queue()
+    with mock.patch('cogs.ReactForRole.ReactForRole.get_rfr_message_from_prompts',
+                    mock.AsyncMock(return_value=(message, channel))):
+        with mock.patch('cogs.ReactForRole.ReactForRole.prompt_for_input', mock.AsyncMock(return_value="Y")):
+            with mock.patch('discord.Message.delete') as mock_msg_delete:
+                await dpytest.message(KoalaBot.COMMAND_PREFIX + "rfr deleteMessage")
+                mock_msg_delete.assert_called_once()
+                dpytest.verify_message(
+                    "Okay, this will delete an existing react for role message. I'll need some details first though.")
+                dpytest.verify_message()
+                dpytest.verify_message()
+                dpytest.verify_message()
+                assert not independent_get_guild_rfr_message(guild.id, channel.id, msg_id)
+
+
+# @pytest.mark.skip("Not implemented yet.")
+@pytest.mark.asyncio
+async def test_rfr_edit_description():
+    config: dpytest.RunnerConfig = dpytest.get_config()
+    guild: discord.Guild = config.guilds[0]
+    channel: discord.TextChannel = guild.text_channels[0]
+    embed: discord.Embed = discord.Embed(title="title", description="description")
+    client: discord.Client = config.client
+    message: discord.Message = await dpytest.message("rfr")
+    msg_id = message.id
+    DBManager.add_rfr_message(guild.id, channel.id, msg_id)
+    assert embed.description == 'description'
+    with mock.patch('cogs.ReactForRole.ReactForRole.get_rfr_message_from_prompts',
+                    mock.AsyncMock(return_value=(message, channel))):
+        with mock.patch('cogs.ReactForRole.ReactForRole.prompt_for_input',
+                        mock.AsyncMock(side_effect=["new description", "Y"])):
+            with mock.patch('cogs.ReactForRole.ReactForRole.get_embed_from_message', return_value=embed):
+                await dpytest.message(KoalaBot.COMMAND_PREFIX + "rfr edit description")
+                assert embed.description == 'new description'
+                dpytest.verify_message()
+                dpytest.verify_message()
+                dpytest.verify_message()
+
+
+@pytest.mark.asyncio
+async def test_rfr_edit_title():
+    config: dpytest.RunnerConfig = dpytest.get_config()
+    guild: discord.Guild = config.guilds[0]
+    channel: discord.TextChannel = guild.text_channels[0]
+    embed: discord.Embed = discord.Embed(title="title", description="description")
+    client: discord.Client = config.client
+    message: discord.Message = await dpytest.message("rfr")
+    msg_id = message.id
+    DBManager.add_rfr_message(guild.id, channel.id, msg_id)
+    assert embed.title == 'title'
+    with mock.patch('cogs.ReactForRole.ReactForRole.get_rfr_message_from_prompts',
+                    mock.AsyncMock(return_value=(message, channel))):
+        with mock.patch('cogs.ReactForRole.ReactForRole.prompt_for_input',
+                        mock.AsyncMock(side_effect=["new title", "Y"])):
+            with mock.patch('cogs.ReactForRole.ReactForRole.get_embed_from_message', return_value=embed):
+                await dpytest.message(KoalaBot.COMMAND_PREFIX + "rfr edit title")
+                assert embed.title == 'new title'
+                dpytest.verify_message()
+                dpytest.verify_message()
+                dpytest.verify_message()
+
+
+@pytest.mark.asyncio
+async def test_rfr_add_roles_to_msg():
+    config: dpytest.RunnerConfig = dpytest.get_config()
+    guild: discord.Guild = config.guilds[0]
+    channel: discord.TextChannel = guild.text_channels[0]
+    embed: discord.Embed = discord.Embed(title="title", description="description")
+    client: discord.Client = config.client
+    author: discord.Member = config.members[0]
+    message: discord.Message = await dpytest.message("rfr")
+    msg_id: int = message.id
+    DBManager.add_rfr_message(guild.id, channel.id, msg_id)
+    input_em_ro_content = ""
+    em_list = []
+    ro_list = []
+    for i in range(5):
+        em = utils.fake_unicode_emoji()
+        ro = utils.fake_guild_role(guild)
+        input_em_ro_content += f"{str(em)}, {ro.id}\n\r"
+        em_list.append(em)
+        ro_list.append(ro.mention)
+    input_em_ro_msg: discord.Message = dpytest.back.make_message(input_em_ro_content, author, channel)
+
+    with mock.patch('cogs.ReactForRole.ReactForRole.get_rfr_message_from_prompts',
+                    mock.AsyncMock(return_value=(message, channel))):
+        with mock.patch('cogs.ReactForRole.ReactForRole.get_embed_from_message', return_value=embed):
+            with mock.patch('cogs.ReactForRole.ReactForRole.wait_for_message', return_value=(input_em_ro_msg, None)):
+                with mock.patch('discord.Embed.add_field') as add_field:
+                    await dpytest.message(KoalaBot.COMMAND_PREFIX + "rfr addRoles")
+                    calls = []
+                    for i in range(5):
+                        calls.append(mock.call(name=str(em_list[i]), value=ro_list[i], inline=False))
+                    add_field.has_calls(calls)
+
+
+@pytest.mark.asyncio
+async def test_rfr_remove_roles_from_msg():
+    config: dpytest.RunnerConfig = dpytest.get_config()
+    guild: discord.Guild = config.guilds[0]
+    channel: discord.TextChannel = guild.text_channels[0]
+    embed: discord.Embed = discord.Embed(title="title", description="description")
+    client: discord.Client = config.client
+    author: discord.Member = config.members[0]
+    message: discord.Message = await dpytest.message("rfr")
+    msg_id: int = message.id
+    DBManager.add_rfr_message(guild.id, channel.id, msg_id)
+    input_em_ro_content = ""
+    em_ro_list = []
+    for i in range(5):
+        em = utils.fake_unicode_emoji()
+        ro = utils.fake_guild_role(guild)
+        x = random.choice([str(em), str(ro.id)])
+        input_em_ro_content += f"{x}\n\r"
+        em_ro_list.append(x)
+        embed.add_field(name=str(em), value=ro.mention, inline=False)
+        DBManager.add_rfr_message_emoji_role(1, str(em), ro.id)
+
+    input_em_ro_msg: discord.Message = dpytest.back.make_message(input_em_ro_content, author, channel)
+    with mock.patch('cogs.ReactForRole.ReactForRole.get_rfr_message_from_prompts',
+                    mock.AsyncMock(return_value=(message, channel))):
+        with mock.patch('cogs.ReactForRole.ReactForRole.get_embed_from_message', return_value=embed):
+            with mock.patch('cogs.ReactForRole.ReactForRole.wait_for_message', return_value=(input_em_ro_msg, None)):
+                with mock.patch('discord.Embed.add_field') as add_field:
+                    with mock.patch(
+                            'cogs.ReactForRole.ReactForRoleDBManager.remove_rfr_message_emoji_role') as remove_emoji_role:
+                        add_field.reset_mock()
+                        await dpytest.message(KoalaBot.COMMAND_PREFIX + "rfr removeRoles")
+                        add_field.assert_not_called()
+                        calls = []
+                        for i in range(5):
+                            calls.append((1, em_ro_list[i]))
+                        remove_emoji_role.has_calls(calls)
+
+
+# role-check tests
+@pytest.mark.parametrize("num_roles, num_required",
+                         [(0, 0), (1, 0), (1, 1), (2, 0), (2, 1), (2, 2), (5, 1), (5, 2), (20, 5)])
+@pytest.mark.asyncio
+async def test_can_have_rfr_role(num_roles, num_required):
+    config: dpytest.RunnerConfig = dpytest.get_config()
+    guild: discord.Guild = config.guilds[0]
+    r_list = []
+    for i in range(num_roles):
+        role = utils.fake_guild_role(guild)
+        r_list.append(role)
+    required = random.sample(set(r_list), num_required)
+    for r in required:
+        DBManager.add_guild_rfr_required_role(guild.id, r.id)
+        assert independent_get_guild_rfr_required_role(guild.id, r.id) is not None
+    for i in range(num_roles):
+        mem_roles = []
+        member: discord.Member = await dpytest.member_join()
+        for j in range(i):
+            mem_roles.append(r_list[j])
+            await member.add_roles(r_list[j])
+
+        assert len(mem_roles) == i
+        if len(required) == 0:
+            assert rfr_cog.can_have_rfr_role(member)
+        else:
+            assert rfr_cog.can_have_rfr_role(member) == any(
+                x in required for x in member.roles), f"\n\r{member.roles}\n\r{required}"
+
+
+@pytest.mark.skip("No support for reactions")
+@pytest.mark.asyncio
+async def test_rfr_without_req_role():
+    assert False
+
+
+@pytest.mark.skip("No support for reactions")
+@pytest.mark.asyncio
+async def test_rfr_with_req_role():
+    assert False
+
+
+@pytest.fixture(scope='session', autouse=True)
+def setup_db():
+    DBManager.get_parent_database_manager().clear_all_tables(
+        DBManager.get_parent_database_manager().fetch_all_tables())
+    yield DBManager
+
+
+@pytest.fixture(scope='session', autouse=True)
+def setup_is_dpytest():
+    KoalaBot.is_dpytest = True
+    yield
+    KoalaBot.is_dpytest = False
+
+
+@pytest.fixture(scope='function', autouse=True)
+async def setup_clean_messages():
+    await dpytest.empty_queue()
+    yield dpytest

--- a/tests/utils/TestUtils.py
+++ b/tests/utils/TestUtils.py
@@ -8,16 +8,20 @@ Commented using reStructuredText (reST)
 # Futures
 
 # Built-in/Generic Imports
+import random
+from string import ascii_letters
 
 # Libs
 import discord
+import emoji
 from discord.ext.test import factories as dpyfactory
-from typing import List
-
 
 # Own modules
 
 # Constants
+unicode_emojis = list(emoji.UNICODE_EMOJI.values())
+emoji_unicodes = list(emoji.EMOJI_UNICODE.values())
+
 
 # Variables
 
@@ -57,6 +61,74 @@ def assert_activity(activity: discord.Activity, application_id=None, name=None, 
            and activity.small_image_url == small_image_url \
            and activity.large_image_text == large_image_text \
            and activity.small_image_text == small_image_text
+
+
+def fake_guild_emoji(guild: discord.Guild) -> discord.Emoji:
+    fake_emoji = discord.Emoji(guild=guild, state=None,
+                               data={'require_colons': True, 'managed': False, 'animated': False,
+                                     'name': fake_custom_emoji_name_str(), 'id': fake_id_str(), 'available': True})
+    return fake_emoji
+
+def fake_partial_emoji() -> discord.PartialEmoji:
+    if random.choice([True, False]):
+        fake_emoji = discord.PartialEmoji(name=fake_custom_emoji_name_str(), animated=random.choice([True, False]), id=dpyfactory.make_id)
+    else:
+        fake_emoji = discord.PartialEmoji(name=fake_unicode_emoji())
+    return fake_emoji
+
+
+def fake_guild_role(guild: discord.Guild) -> discord.Role:
+    fake_role = discord.Role(guild=guild, state=None,
+                             data={'id': dpyfactory.make_id(), 'name': fake_custom_emoji_name_str(),
+                                   'mentionable': True, 'hoist': True, 'managed': False,
+                                   'colour': random.randint(0, 16777215), 'permissions': 8})
+    guild._add_role(fake_role)
+    return fake_role
+
+
+def fake_custom_emoji_str_rep() -> str:
+    """
+    Creates a fake string representation of a discord custom emoji.
+    :return:
+    """
+    emoji_str = ""
+    emoji_str += random.choice(["<a:", "<:"])
+    emoji_str += ''.join(random.choice(ascii_letters) for i in range(random.randint(4, 12)))
+    emoji_str += f":{dpyfactory.make_id()}>"
+    return emoji_str
+
+
+def fake_custom_emoji_name_str() -> str:
+    return ''.join(random.choice(ascii_letters) for i in range(random.randint(4, 12)))
+
+
+def fake_unicode_emoji() -> str:
+    """
+    Creates a fake unicode emoji (the string representation with colons)
+    :return:
+    """
+    return random.choice(unicode_emojis)
+
+def fake_emoji_unicode() -> str:
+    """
+    Returns a random unicode emoji's unicode codepoint
+    """
+    return random.choice(emoji_unicodes)
+
+def fake_role_mention() -> str:
+    """
+    Creates a fake role mention string.
+    :return:
+    """
+    return "<@&" + str(dpyfactory.make_id()) + ">"
+
+
+def fake_id_str() -> str:
+    """
+    Creates a fake id string, e.g. message ID, role ID, etc.
+    :return:
+    """
+    return str(dpyfactory.make_id())
 
 
 class FakeAuthor:

--- a/utils/KoalaUtils.py
+++ b/utils/KoalaUtils.py
@@ -19,7 +19,6 @@ from utils.KoalaColours import *
 # Constants
 ID_LENGTH = 18
 
-
 # Variables
 
 
@@ -28,8 +27,8 @@ def random_id():
     Creates a random int id of length ID_LENGTH
     :return: The randomly generated ID_LENGTH length number
     """
-    range_start = 10**(ID_LENGTH-1)
-    range_end = (10**ID_LENGTH)-1
+    range_start = 10 ** (ID_LENGTH - 1)
+    range_end = (10 ** ID_LENGTH) - 1
     return random.randint(range_start, range_end)
 
 


### PR DESCRIPTION
* Add ReactForRole.py.

* Add emoji to list of requirements

* Add emoji regex string to match. May be removed later.

* Temporarily comment out error embed - currently absorbs stack trace.

* Large commit
 - Add database management
 - Add createInChannel command
 - Organise into command groups for intuitive use
 - Add addRoles command.

* Add and implement reaction remove and add listeners.

* Remove EMOJI_REGEXP due to being replaced by a dependency.

* Fix incorrect colour role position calculation

* Add remove role from existing message functionality to cog.

* Update to keep in line with requirements.txt

* Add check for case where all embed fields are removed from rfr message in removeRoles

* Add remove message functionality (removeMessage command) to cog.

* Fix channel permission overwrite permissions function to account for bot roles, and just disallow new reacts from other roles.

* Add edit rfr message title functionality (rfr edit title command) to cog.

* Fix test fail to match earlier fix in commit b03abfd81297a9fe80dceea23f22890aa06db6b9

* Change RFRMessageEmojiRoles table schema

* Fix error in RFRMessageEmojiRoles schema causing new entries to not be added due to incorrect UNIQUE constraint

* Fix ON DELETE CASCADE not working as intended by removing it and replacing with method calls.

* Add test module. Add database manager function tests.

* Add fake generators for IDs, roles, emojis, and their string representations in Discord

* Fix an error log message not being correctly formatted

* Add test for get_rfr_message_from_prompts(). Add debug stub test for parse_emoji_and_role_input_str(), TBD

* Add test for parse_emoji_and_role_input_str()

* Add fake_partial_emoji util func for test purposes

* Edit wait_for_message in prompt_for)input and edit NoneType msg error msg send

* Add stub tests for parse_emoji_or_roles_input_str and overwrite_channel_add_reaction_perms. Add test for prompt_for_input

* Change overwrite_channel_add_reaction_perms to need guild arg instead of context

* Fix test for overwrite_channel_add_reaction_perms() using mock

* Add tests for wait_for_message()

* Add test for is_user_alive()

* Add check for IndexError in get_embed_from_message()

* Add test for get_embed_from_message()

* Add test for get_number_of_embed_fields()

* Reformat

* Add test for discord cmd k!rfr createMessage

* Remove debug messages from rfr_create_message

* Add ReactForRole.py.

* Add emoji to list of requirements

* Add emoji regex string to match. May be removed later.

* Temporarily comment out error embed - currently absorbs stack trace.

* Large commit
 - Add database management
 - Add createInChannel command
 - Organise into command groups for intuitive use
 - Add addRoles command.

* Add and implement reaction remove and add listeners.

* Remove EMOJI_REGEXP due to being replaced by a dependency.

* Fix incorrect colour role position calculation

* Add remove role from existing message functionality to cog.

* Update to keep in line with requirements.txt

* Add check for case where all embed fields are removed from rfr message in removeRoles

* Add remove message functionality (removeMessage command) to cog.

* Fix channel permission overwrite permissions function to account for bot roles, and just disallow new reacts from other roles.

* Add edit rfr message title functionality (rfr edit title command) to cog.

* Fix test fail to match earlier fix in commit b03abfd81297a9fe80dceea23f22890aa06db6b9

* Change RFRMessageEmojiRoles table schema

* Fix error in RFRMessageEmojiRoles schema causing new entries to not be added due to incorrect UNIQUE constraint

* Fix ON DELETE CASCADE not working as intended by removing it and replacing with method calls.

* Add test module. Add database manager function tests.

* Add fake generators for IDs, roles, emojis, and their string representations in Discord

* Fix an error log message not being correctly formatted

* Add test for get_rfr_message_from_prompts(). Add debug stub test for parse_emoji_and_role_input_str(), TBD

* Add test for parse_emoji_and_role_input_str()

* Add fake_partial_emoji util func for test purposes

* Edit wait_for_message in prompt_for)input and edit NoneType msg error msg send

* Add stub tests for parse_emoji_or_roles_input_str and overwrite_channel_add_reaction_perms. Add test for prompt_for_input

* Change overwrite_channel_add_reaction_perms to need guild arg instead of context

* Fix test for overwrite_channel_add_reaction_perms() using mock

* Add tests for wait_for_message()

* Add test for is_user_alive()

* Add check for IndexError in get_embed_from_message()

* Add test for get_embed_from_message()

* Add test for get_number_of_embed_fields()

* Reformat

* Add test for discord cmd k!rfr createMessage

* Remove debug messages from rfr_create_message

* Add test for k!rfr deleteMessage

* Fix typo in rfr_edit_title. Add database + db functions for roles able to get rfr roles.

* Auto-format

* Add stub test for rfr_edit_description

* Add role-check functionality:
 - checks if user has role/needs one to use rfr
 - if not, removes all rfr roles from them
 - check occurs only on user reaction remove/add however.

* Add logging for error in on_raw_reaction_add(). Add case check for that.

* Add assertion for no unnecessary message sent after k!customColour valid and increase max number of roles tested in tests.

* Add test for k!rfr edit removeRoles, title and addRoles. Add failing test for can_have_rfr_role

* update ReactForRole branch (#56)

* bug fix

fixed error when user was verified for server they werent in

* Update CHANGELOG.md

* forgot to pull before making change?

* Update CHANGELOG.md

* Fix TwitchAlert loops crashing

* Fix Oauth and Add windows dbManaged

* Fix old headers

* Add timeout for requests

* Update CHANGELOG.md

* Fix Twitch API Limits followed

* Fix wrong usernames

* Temporary Disable Twitch Cog

* Adjust Time on requests

* Add check oauth is not None

* Disabled on_command_error for debugging

* Add debuging prints

appologies for the mess

* Timeout increased

* Update TwitchAlert to use aiohttp rather than requests

* Fix Tests to work with adjusted async methods

* Update test_TwitchAlert.py

* Update .gitignore

* Remove obsolete code

* Fix fake/ old message ids crashing on delete

* Re-enable discord command error

* Update Changelog for 0.1.4

* Update Verification.py

allow startup assigning to skip guilds its been removed from

* Update CHANGELOG.md

* Add regex for twitch usernames

* Update Changelog for v0.1.5

* Minor Fixes

* Removed debug changes from TwitchAlert.py

* Fix incorrect sqlite import

* Update Changelog for v0.1.6

* Fix InvalidArgument errors from not showing & Add logging

### Twitch Alert
##### Changed
- Fix InvalidArgument errors from not showing
- Add logging

* Add removal of chats that are no longer accessible

* Fix remove_user_from_ta sql

* Update Changelog for v0.1.7

* Update TwitchAlert.py

* Fix 'No Category' issue

- Add 'No Category' option
- Reduced Logging
- Fix regex allowing underscore at start of name

* Update Changelog for v0.1.8

* Add travis file

* PR changes - use old versions of discordpy and dpytest

* Add catch so errors don't stop the alert loop (#54)

* Add catch so errors don't stop the alert loop

* Remove old code & tidy up readability

Co-authored-by: largereptile <harry@yark.org.uk>
Co-authored-by: Jack Draper <drapj002@gmail.com>
Co-authored-by: Kaspiaan <57161931+Kaspiaan@users.noreply.github.com>
Co-authored-by: Viraj Shah <47211319+VirajShah18@users.noreply.github.com>
Co-authored-by: Stefan Cooper <stefan.cooper27@gmail.com>

* Fix role check errors caused by faulty database manager function

* Add database tests for required role checks

* Move test_rfr_db_functions_guild_rfr_required_roles() up to prevent error in pre-test cleanup

* Auto-reformat

* Add command checks. Remove some unnecessary message sends.

* Update requirements.txt

Co-authored-by: Jack Draper <drapj002@gmail.com>

* Update KoalaBot.py

Co-authored-by: Jack Draper <drapj002@gmail.com>

* Temporary Disable Twitch Cog

* Adjust Time on requests

* Disabled on_command_error for debugging

* Fix Tests to work with adjusted async methods

* Update test_TwitchAlert.py

* Re-enable discord command error

* Update Changelog for v0.1.8

* Add catch so errors don't stop the alert loop (#54)

* Add catch so errors don't stop the alert loop

* Remove old code & tidy up readability

* fix: update Python to 3.8 in Travis (#58)

* feat: add Text Filter (#51)

* Add Text Filter

* Add tests for text filter

* Renamed TextFilter and fixed database links

* Added CHANGELOG information

* Added list ignored

* Fixed tests and added ignore list test

* Bug testing travis

* Clear queue after each test to determine failing test

* Test removing warnings

* Refactored database calls

* PR Changes

* PR Changes 2

* PR CHanges 3

* Small cleanup

* Further cleanup

* Add RFR to CHANGELOG.md

* Update cogs/ReactForRole.py

Co-authored-by: Jack Draper <drapj002@gmail.com>

* Add missing extension enabled checks.

* Add docstrings for commands.

* Remove unnecessary ctx.send call and fix wait_for_message() return values

* Fix test_rfr_create_message

* Change message command names + aliases

* Add docstrings for ReactForRole class. Change can_have_rfr_role to a synchronous method.

* Update CHANGELOG.md

* Fixes bug in #59

* Update cogs/ReactForRole.py

Co-authored-by: Jack Draper <drapj002@gmail.com>

* Update CHANGELOG.md

* Add colour to new embed in k!rfr delete

* Add longer timeout for addRoles. Add check for bot reaction add/remove. Only overwrite channel perms for \@everyone role. Fix DB error.

* Fix test for overwrite_channel_add_reaction_perms to match changes in ReactForRole.py

* Fix test_rfr_create_message after message change in ReactForRole.py

* Add most of pr #57 requested changes.

* Move get_rfr_reaction_role_by_role_id to here since only usage is in this file

* Fix backslashes in docstrings

* Whitespace

* Cleanup old code. Fix issue where bot can't find rfr message in another channel 1/10 times.

* Add check for non-rfr emote in reaction add

* Change Koala image URL to be global

Co-authored-by: largereptile <harry@yark.org.uk>
Co-authored-by: Jack Draper <drapj002@gmail.com>
Co-authored-by: Kaspiaan <57161931+Kaspiaan@users.noreply.github.com>
Co-authored-by: Viraj Shah <47211319+VirajShah18@users.noreply.github.com>
Co-authored-by: Stefan Cooper <stefan.cooper27@gmail.com>