### PR TITLE
fix: add regex validation to ensure valid regex only on TF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to KoalaBot will be documented in this file.
 A lot of these commands will only be available to administrators
 
 ## [Unreleased]
+### Text Filter
+##### Changed
+- Add regex validation to ensure valid regex only
 
 ## [0.2.0] - 15-10-2020
 ### Text Filter

--- a/cogs/TextFilter.py
+++ b/cogs/TextFilter.py
@@ -87,14 +87,18 @@ class TextFilter(commands.Cog, name="TextFilter"):
         :param too_many_arguments: Used to check if too many arguments have been given
         :return:
         """
-        error = """Something has gone wrong, this regex may already be filtered or you have entered the " 
-                command incorrectly. Try again with: `k!filterRegex [filtered_regex] [[risky] or [banned]]`. 
-                One example for a regex could be to block emails with: 
-                [a-zA-Z0-9\._]+@herts\.ac\.uk where EMAIL is the university type (e.g herts)"""
+        error = """Something has gone wrong, your regex may be invalid, this regex may already be filtered
+                or you have entered the command incorrectly. Try again with: `k!filterRegex 
+                [filtered_regex] [[risky] or [banned]]`. One example for a regex could be to block emails
+                with: [a-zA-Z0-9\._]+@herts\.ac\.uk where EMAIL is the university type (e.g herts)"""
         if too_many_arguments is None and type_exists(filter_type):
-            await self.filter_text(ctx, regex, filter_type, True)
-            await ctx.channel.send("*" + regex + "* has been filtered as **"+filter_type+"**.")
-            return
+            try:
+                re.compile(regex)
+                await self.filter_text(ctx, regex, filter_type, True)
+                await ctx.channel.send("*" + regex + "* has been filtered as **"+filter_type+"**.")
+                return
+            except:
+                raise Exception(error)    
         raise Exception(error)
 
     @commands.command(name="unfilter", aliases=["unfilter_word"])

--- a/tests/test_TextFilter.py
+++ b/tests/test_TextFilter.py
@@ -165,6 +165,12 @@ async def test_filter_email_regex():
     cleanup(dpytest.get_config().guilds[0].id)
 
 @pytest.mark.asyncio()
+async def test_invalid_regex():
+    with pytest.raises(Exception):
+        await dpytest.message(KoalaBot.COMMAND_PREFIX + "filter_regex [")
+    cleanup(dpytest.get_config().guilds[0].id)
+
+@pytest.mark.asyncio()
 async def test_filter_various_emails_with_regex():
     await dpytest.message(KoalaBot.COMMAND_PREFIX + "filter_regex [a-z0-9]+[\._]?[a-z0-9]+[@]+[herts]+[.ac.uk]")
     assertFilteredConfirmation("[a-z0-9]+[\._]?[a-z0-9]+[@]+[herts]+[.ac.uk]","banned")


### PR DESCRIPTION
This PR adds a small regex validation when users try to add a filtered regex to only allow valid regex.