### PR TITLE
fix: fix for regex incorrectly being used on some messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to KoalaBot will be documented in this file.
 A lot of these commands will only be available to administrators
 
 ## [Unreleased]
+### Text Filter
+##### Changed
+- Add regex validation to ensure valid regex only
 
 ## [0.2.0] - 15-10-2020
 ### Text Filter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ A lot of these commands will only be available to administrators
 ### Text Filter
 ##### Changed
 - Add regex validation to ensure valid regex only
+- Fix mod channel not saving correctly
 
 ## [0.2.0] - 15-10-2020
 ### Text Filter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ A lot of these commands will only be available to administrators
 ##### Changed
 - Add regex validation to ensure valid regex only
 - Fix mod channel not saving correctly
+- Fix regex incorrectly being used on some messages
 
 ## [0.2.0] - 15-10-2020
 ### Text Filter

--- a/cogs/TextFilter.py
+++ b/cogs/TextFilter.py
@@ -282,7 +282,7 @@ class TextFilter(commands.Cog, name="TextFilter"):
         elif str(message.channel.type) == 'text' and message.channel.guild is not None:
             censor_list = self.tf_database_manager.get_filtered_text_for_guild(message.channel.guild.id)
             for word, filter_type, is_regex in censor_list:
-                if (word in message.content or re.search(word, message.content)) and not self.is_ignored(message):
+                if (word in message.content or (is_regex == '1' and re.search(word, message.content))) and not self.is_ignored(message):
                     if filter_type == "risky":
                         await message.author.send("Watch your language! Your message: '*"+message.content+"*' in " +
                                                   message.channel.mention+" contains a 'risky' word. "

--- a/cogs/TextFilter.py
+++ b/cogs/TextFilter.py
@@ -87,14 +87,18 @@ class TextFilter(commands.Cog, name="TextFilter"):
         :param too_many_arguments: Used to check if too many arguments have been given
         :return:
         """
-        error = """Something has gone wrong, this regex may already be filtered or you have entered the " 
-                command incorrectly. Try again with: `k!filterRegex [filtered_regex] [[risky] or [banned]]`. 
-                One example for a regex could be to block emails with: 
-                [a-zA-Z0-9\._]+@herts\.ac\.uk where EMAIL is the university type (e.g herts)"""
+        error = """Something has gone wrong, your regex may be invalid, this regex may already be filtered
+                or you have entered the command incorrectly. Try again with: `k!filterRegex 
+                [filtered_regex] [[risky] or [banned]]`. One example for a regex could be to block emails
+                with: [a-zA-Z0-9\._]+@herts\.ac\.uk where EMAIL is the university type (e.g herts)"""
         if too_many_arguments is None and type_exists(filter_type):
-            await self.filter_text(ctx, regex, filter_type, True)
-            await ctx.channel.send("*" + regex + "* has been filtered as **"+filter_type+"**.")
-            return
+            try:
+                re.compile(regex)
+                await self.filter_text(ctx, regex, filter_type, True)
+                await ctx.channel.send("*" + regex + "* has been filtered as **"+filter_type+"**.")
+                return
+            except:
+                raise Exception(error)    
         raise Exception(error)
 
     @commands.command(name="unfilter", aliases=["unfilter_word"])

--- a/cogs/TextFilter.py
+++ b/cogs/TextFilter.py
@@ -150,7 +150,7 @@ class TextFilter(commands.Cog, name="TextFilter"):
         error = "Channel not found or too many arguments, please try again: `k!setupModChannel [channel_id]`"
         channel = self.bot.get_channel(int(extract_id(channel_id)))
         if channel is not None and too_many_arguments is None:
-            self.tf_database_manager.new_mod_channel(ctx.guild.id, channel_id)
+            self.tf_database_manager.new_mod_channel(ctx.guild.id, channel.id)
             await ctx.channel.send(embed=build_moderation_channel_embed(ctx, channel, "Added"))
             return
         raise(Exception(error))

--- a/tests/test_TextFilter.py
+++ b/tests/test_TextFilter.py
@@ -21,6 +21,7 @@ from tests.utils import TestUtilsCog
 from tests.utils.TestUtils import assert_activity
 from utils import KoalaDBManager
 from utils.KoalaColours import *
+from utils.KoalaUtils import is_int
 
 # Variables
 base_cog = None
@@ -239,6 +240,25 @@ async def test_add_mod_channel():
     await dpytest.message(KoalaBot.COMMAND_PREFIX + "setupModChannel "+str(channel.id))
     assert_embed = createNewModChannelEmbed(channel)
     dpytest.verify_embed(embed=assert_embed)
+    cleanup(dpytest.get_config().guilds[0].id)
+
+
+@pytest.fixture
+def text_filter_db_manager():
+    return TextFilter.TextFilterDBManager(KoalaDBManager.KoalaDBManager(KoalaBot.DATABASE_PATH, KoalaBot.DB_KEY), dpytest.get_config())
+
+
+@pytest.mark.asyncio()
+async def test_add_mod_channel_tag(text_filter_db_manager):
+    channel = dpytest.backend.make_text_channel(name="TestChannel", guild=dpytest.get_config().guilds[0])
+    dpytest.get_config().channels.append(channel)
+
+    await dpytest.message(KoalaBot.COMMAND_PREFIX + "setupModChannel <#"+str(channel.id)+">")
+    assert_embed = createNewModChannelEmbed(channel)
+    dpytest.verify_embed(embed=assert_embed)
+
+    result = text_filter_db_manager.database_manager.db_execute_select("SELECT channel_id FROM TextFilterModeration WHERE guild_id = ?;", args=[channel.guild.id])
+    assert is_int(result[0][0])
     cleanup(dpytest.get_config().guilds[0].id)
 
 @pytest.mark.asyncio()

--- a/tests/test_TextFilter.py
+++ b/tests/test_TextFilter.py
@@ -165,6 +165,12 @@ async def test_filter_email_regex():
     cleanup(dpytest.get_config().guilds[0].id)
 
 @pytest.mark.asyncio()
+async def test_invalid_regex():
+    with pytest.raises(Exception):
+        await dpytest.message(KoalaBot.COMMAND_PREFIX + "filter_regex [")
+    cleanup(dpytest.get_config().guilds[0].id)
+
+@pytest.mark.asyncio()
 async def test_filter_various_emails_with_regex():
     await dpytest.message(KoalaBot.COMMAND_PREFIX + "filter_regex [a-z0-9]+[\._]?[a-z0-9]+[@]+[herts]+[.ac.uk]")
     assertFilteredConfirmation("[a-z0-9]+[\._]?[a-z0-9]+[@]+[herts]+[.ac.uk]","banned")

--- a/tests/test_TextFilter.py
+++ b/tests/test_TextFilter.py
@@ -172,6 +172,14 @@ async def test_invalid_regex():
     cleanup(dpytest.get_config().guilds[0].id)
 
 @pytest.mark.asyncio()
+async def test_normal_filter_does_not_recognise_regex():
+    await dpytest.message(KoalaBot.COMMAND_PREFIX + "filter \"^verify [a-zA-Z0-9]+@soton.ac.uk$\"")
+    assertFilteredConfirmation("^verify [a-zA-Z0-9]+@soton.ac.uk$", "banned")
+
+    await dpytest.message("verify abc@soton.ac.uk")
+    dpytest.verify_message(assert_nothing=True)
+
+@pytest.mark.asyncio()
 async def test_filter_various_emails_with_regex():
     await dpytest.message(KoalaBot.COMMAND_PREFIX + "filter_regex [a-z0-9]+[\._]?[a-z0-9]+[@]+[herts]+[.ac.uk]")
     assertFilteredConfirmation("[a-z0-9]+[\._]?[a-z0-9]+[@]+[herts]+[.ac.uk]","banned")
@@ -186,9 +194,12 @@ async def test_filter_various_emails_with_regex():
 
     # Should not warn
     await dpytest.message("hey herts.ac.uk")
+    dpytest.verify_message(assert_nothing=True)
 
     # Should not warn
     await dpytest.message("hey stefan@herts")
+    dpytest.verify_message(assert_nothing=True)
+
     cleanup(dpytest.get_config().guilds[0].id)
 
 @pytest.mark.asyncio()

--- a/utils/KoalaUtils.py
+++ b/utils/KoalaUtils.py
@@ -65,6 +65,6 @@ def extract_id(raw_id):
             raw_id = raw_id[1:]
         return int(raw_id[:-1])
     elif is_int(raw_id):
-        return raw_id
+        return int(raw_id)
     else:
         raise TypeError("ID given is not a valid ID")


### PR DESCRIPTION
This PR adds a better check to ensure that we only check regex on filters that have been added as 'regex'