### PR TITLE
Add documentation json from frontend

### DIFF
--- a/documentation.json
+++ b/documentation.json
@@ -1,0 +1,252 @@
+[
+  {
+    "name": "Base",
+    "commands": [
+      {
+        "command": "enableExt",
+        "parameters": ["koala_extension"],
+        "description": "Enable available Koala Extensions"
+      },
+      {
+        "command": "disableExt",
+        "parameters": ["koala_extension"],
+        "description": "Disable enabled Koala Extensions"
+      },
+      {
+        "command": "listExt",
+        "parameters": [],
+        "description": "Lists all enabled and disabled Koala Extensions"
+      },
+      {
+        "command": "welcomeUpdateMsg",
+        "parameters": [],
+        "description": "Allows admins to change their customisable part of the welcome message of a guild."
+      },
+      {
+        "command": "welcomeSendMsg",
+        "parameters": [],
+        "description": "Allows admins to send out their welcome message manually to all members of a guild."
+      },
+      {
+        "command": "welcomeViewMsg",
+        "parameters": [],
+        "description": "Shows the current welcome message"
+      },
+      {
+        "command": "clear",
+        "parameters": ["amount"],
+        "description": "Clears a given number of messages from the given channel."
+      },
+      {
+        "command": "ping",
+        "parameters": [],
+        "description": "Returns the ping of a bot"
+      }
+    ]
+  },
+  {
+    "name": "Verify",
+    "commands": [
+      {
+        "command": "verifyAdd",
+        "parameters": ["suffix", "role"],
+        "description": "Set up a role and email pair for KoalaBot to verify users with"
+      },
+      {
+        "command": "verifyRemove",
+        "parameters": ["suffix", "role"],
+        "description": "Disable an existing verification listener"
+      },
+      {
+        "command": "reVerify",
+        "parameters": ["role"],
+        "description": "Removes a role from all users who have it and marks them as needing to re-verify before giving it back."
+      },
+      {
+        "command": "verifyList",
+        "parameters": ["channelId"],
+        "description": "List the current verification setup for the server"
+      }
+    ]
+  },
+  {
+    "name": "Twitch Alert",
+    "commands": [
+      {
+        "command": "twitchEditMsg",
+        "parameters": ["channel_id", "default_live_message"],
+        "description": "Edit the default message put in a Twitch Alert Notification"
+      },
+      {
+        "command": "twitchViewMsg",
+        "parameters": ["channel_id"],
+        "description": "Shows the current default message for Twitch Alerts"
+      },
+      {
+        "command": "twitchList",
+        "parameters": [],
+        "description": "Shows all current users and teams in a Twitch Alert"
+      },
+      {
+        "command": "twitchAdd",
+        "parameters": ["channel_id", "twitch_username", "custom_live_message"],
+        "description": "Add a Twitch user to a Twitch Alert"
+      },
+      {
+        "command": "twitchRemove",
+        "parameters": ["channel_id", "twitch_username"],
+        "description": "Remove a user from a Twitch Alert"
+      },
+      {
+        "command": "twitchAddTeam",
+        "parameters": ["channel_id", "team_name", "custom_live_message"],
+        "description": "Add a Twitch team to a Twitch alert"
+      },
+      {
+        "command": "twitchRemoveTeam",
+        "parameters": ["channel_id", "team_name"],
+        "description": "Edit the default message put in a Twitch Alert Notification"
+      }
+    ]
+  },
+  {
+    "name": "Colour Role",
+    "commands": [
+      {
+        "command": "listCustomColourAllowedRoles",
+        "parameters": [],
+        "description": "Lists the roles in a guild which are permitted to have their own custom colours."
+      },
+      {
+        "command": "listProtectedRoleColours",
+        "parameters": [],
+        "description": "Lists the protected roles, whose colours are protected from being imitated by a custom colour, in a guild."
+      },
+      {
+        "command": "addCustomColourAllowedRole",
+        "parameters": ["role"],
+        "description": "Adds a role, via ID, mention or name, to the list of roles allowed to have a custom colour."
+      },
+      {
+        "command": "addProtectedRoleColour",
+        "parameters": ["role_str"],
+        "description": "Adds a role, via ID, mention or name, to the list of protected roles."
+      },
+      {
+        "command": "removeCustomColourAllowedRole",
+        "parameters": ["role_str"],
+        "description": "Removes a role, via ID, mention or name, from the list of roles allowed to have a custom colour."
+      },
+      {
+        "command": "removeProtectedRoleColour",
+        "parameters": ["role_str"],
+        "description": "Removes a role, via ID, mention or name, from the list of protected roles."
+      }
+    ]
+  },
+  {
+    "name": "React for Role (RFR)",
+    "commands": [
+      {
+        "command": "rfr create",
+        "parameters": [],
+        "description": "Create a new, blank rfr message. Default title is React for Role. Default description is Roles below!"
+      },
+      {
+        "command": "rfr delete",
+        "parameters": [],
+        "description": "Delete an existing rfr message."
+      },
+      {
+        "command": "rfr addRequiredRole",
+        "parameters": [],
+        "description": "Add a role required to react to/use rfr functionality. If no role is added, anyone can use rfr functionality."
+      },
+      {
+        "command": "rfr removeRequiredRole",
+        "parameters": [],
+        "description": "Removes a role from the group of roles someone requires to use rfr functionality."
+      },
+      {
+        "command": "rfr edit addRoles",
+        "parameters": [],
+        "description": "Add emoji/role combos to an existing rfr message."
+      },
+      {
+        "command": "rfr edit removeRoles",
+        "parameters": [],
+        "description": "Remove emoji/role combos from an existing rfr message."
+      },
+      {
+        "command": "rfr edit description",
+        "parameters": [],
+        "description": "Edit the description of an existing rfr message."
+      },
+      {
+        "command": "rfr edit title",
+        "parameters": [],
+        "description": "Edit the title of an existing rfr message."
+      }
+    ]
+  },
+  {
+    "name": "Text Filter",
+    "commands": [
+      {
+        "command": "filter",
+        "parameters": ["text", "type"],
+        "description": "Filter a word or string of text. Type is defaulted to 'banned' which will delete the message and warn the user. Use type 'risky' to just warn the user."
+      },
+      {
+        "command": "filterRegex",
+        "parameters": ["regex", "type"],
+        "description": "Filter a regex string. Type is defaulted to 'banned' which will delete the message and warn the user. Use type 'risky' to just warn the user."
+      },
+      {
+        "command": "filterList",
+        "parameters": [],
+        "description": "Get a list of filtered words in the server."
+      },
+      {
+        "command": "modChannelAdd",
+        "parameters": ["channelId"],
+        "description": " Add a mod channel for receiving filtered message information (User, Timestamp, Message) to be sent to."
+      },
+      {
+        "command": "modChannelRemove",
+        "parameters": ["channelId"],
+        "description": "Remove a mod channel from the server."
+      },
+      {
+        "command": "modChannelList",
+        "parameters": [],
+        "description": "See a list of mod channels in the server."
+      },
+      {
+        "command": "ignoreUser",
+        "parameters": ["userMention"],
+        "description": "Add a new ignored user for the server. This users' messages will be ignored by the Text Filter."
+      },
+      {
+        "command": "ignoreChannel",
+        "parameters": ["channelMention"],
+        "description": "Add a new ignored channel for the server. Messages in this channel will be ignored by the Text Filter."
+      },
+      {
+        "command": "ignoreList",
+        "parameters": [""],
+        "description": "See a list of ignored users/channels in the server."
+      },
+      {
+        "command": "unfilter",
+        "parameters": ["text"],
+        "description": "Unfilter a word/string/regex of text that was previously filtered."
+      },
+      {
+        "command": "unignore",
+        "parameters": ["mention"],
+        "description": "Unignore a user/channel that was previously set as ignored."
+      }
+    ]
+  }
+]


### PR DESCRIPTION
This PR adds the documentation json from the frontend to the backend.

It makes sense for the backend to maintain this document for future commands (and the newly added `vote` command)

This JSON will be outputted in the documentation page in the frontend (designs pending): https://koala-staging.herokuapp.com/documentation

The JSON format could change in the future to reflect future design decisions (adding a `usage` field or an `example` field akin to carl.gg). The frontend team will communicate with the backend team to ensure these changes reflect the commands adequately.

Contributes to: #119 

Signed-off-by: Stefan Cooper <stefan.cooper27@gmail.com>