### PR TITLE
reverted dpytest and pysqlcipher3 back to using version numbers instead of git

### DIFF
--- a/production-requirements.txt
+++ b/production-requirements.txt
@@ -6,7 +6,7 @@ certifi==2020.12.5
 chardet==4.0.0
 colorama==0.4.4
 discord.py==1.7.1
-git+https://github.com/KoalaBotUK/dpytest@ebfcdb5b5b5232183615107ff9cf88a5b7773406 # dpytest
+dpytest==0.0.23
 emoji==0.6.0
 idna==2.10
 iniconfig==1.1.1
@@ -18,7 +18,7 @@ parsedatetime==2.6
 pluggy==0.13.1
 py==1.10.0
 pyparsing==2.4.7
-git+https://github.com/rigglemania/pysqlcipher3@1f1b703b9e35205946c820e735f58799e1b72d2d # pysqlcipher3
+pysqlcipher3==1.0.4
 pytest==6.2.3
 pytest-asyncio==0.15.0
 pytest-ordering==0.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ certifi==2020.12.5
 chardet==4.0.0
 colorama==0.4.4
 discord.py==1.7.1
-git+https://github.com/KoalaBotUK/dpytest@ebfcdb5b5b5232183615107ff9cf88a5b7773406 # dpytest
+dpytest==0.0.23
 emoji==0.6.0
 idna==2.10
 iniconfig==1.1.1
@@ -18,7 +18,7 @@ parsedatetime==2.6
 pluggy==0.13.1
 py==1.10.0
 pyparsing==2.4.7
-git+https://github.com/rigglemania/pysqlcipher3@1f1b703b9e35205946c820e735f58799e1b72d2d # pysqlcipher3
+pysqlcipher3==1.0.4
 pytest==6.2.3
 pytest-asyncio==0.15.0
 pytest-ordering==0.6


### PR DESCRIPTION
Previously used `git+URL@commit`, reverted back to `library==version` within requirements.txt 