### PR TITLE
Remove env requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,13 @@ All notable changes to KoalaBot will be documented in this file.
 A lot of these commands will only be available to administrators
 
 ## [Unreleased]
-###Announce
+### Announce
 - Announce is now enabled successfully
+### Other
+- KoalaBot can now be started without Twitch or Gmail keys (disabling TwitchAlert and Verify)
 
 ## [0.4.0] - 06-04-2021
-###Announce
+### Announce
 ##### Added
 - `announce create` Start the creation of an announcement
 - `announce changeTitle` Changes the title of a pending announcement

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ A lot of these commands will only be available to administrators
 - Announce is now enabled successfully
 ### Other
 - KoalaBot can now be started without Twitch or Gmail keys (disabling TwitchAlert and Verify)
+- Owner only commands fall back to bot owner if `BOT_OWNER` is not provided
 
 ## [0.4.0] - 06-04-2021
 ### Announce

--- a/KoalaBot.py
+++ b/KoalaBot.py
@@ -36,7 +36,7 @@ from utils.KoalaUtils import error_embed
 logging.basicConfig(filename='KoalaBot.log')
 load_dotenv()
 BOT_TOKEN = os.environ['DISCORD_TOKEN']
-BOT_OWNER = os.environ['BOT_OWNER']
+BOT_OWNER = os.environ.get('BOT_OWNER')
 DB_KEY = os.environ.get('SQLITE_KEY', "2DD29CA851E7B56E4697B0E1F08507293D761A05CE4D1B628663F411A8086D99")
 COMMAND_PREFIX = "k!"
 STREAMING_URL = "https://twitch.tv/jaydwee"
@@ -76,8 +76,10 @@ def is_owner(ctx):
     """
     if is_dm_channel(ctx):
         return False
-    else:
+    elif BOT_OWNER is not None:
         return ctx.author.id == int(BOT_OWNER) or is_dpytest
+    else:
+        return client.is_owner(ctx.author) or is_dpytest
 
 
 def is_admin(ctx):

--- a/README.md
+++ b/README.md
@@ -45,21 +45,21 @@ Before running the bot you will need to create a `.env` file in the root directo
 ```dotenv
 # Discord Bot
 DISCORD_TOKEN = AdiSc0RdT0k3N # A discord Token taken from the discord developers portal 
-BOT_OWNER = 123456789 # A discord ID for the person who should have access to owner commands
+BOT_OWNER = 123456789 # (optional) A discord ID for the person who should have access to owner commands (will default to bot owner)
 
 # Encryption (optional)
 ENCRIPTION = False # or True (default) for disabling/enabling the database encryption
+SQLITE_KEY = 123EXAMPLE456ENCRYPTION789KEY0 # A custom SQLcipher key
 
-# Twitch Alert
+# Twitch Alert (Required for TwitchAlert Extension)
 TWITCH_TOKEN = tw1tch70k3n # Twitch Token taken from the twitch developers portal
 TWITCH_SECRET = tw1tch53cr3t # Twitch Secret taken from the twitch developers portal
 
-# Verification
+# Verification (Required for Verify Extension)
 GMAIL_EMAIL = example@gmail.com # email for a gmail account
 GMAIL_PASSWORD = example_password123 # password for the same gmail account
-
-
 ```
+`DISCORD_TOKEN` is the only required environment variable for KoalaBot to be run.
 
 ## Running the tests
 Tests are run using `pytest`

--- a/cogs/TwitchAlert.py
+++ b/cogs/TwitchAlert.py
@@ -33,8 +33,8 @@ load_dotenv()
 DEFAULT_MESSAGE = ""
 TWITCH_ICON = "https://cdn3.iconfinder.com/data/icons/social-messaging-ui-color-shapes-2-free" \
               "/128/social-twitch-circle-512.png"
-TWITCH_CLIENT_ID = os.environ['TWITCH_TOKEN']
-TWITCH_SECRET = os.environ['TWITCH_SECRET']
+TWITCH_CLIENT_ID = os.environ.get('TWITCH_TOKEN')
+TWITCH_SECRET = os.environ.get('TWITCH_SECRET')
 TWITCH_USERNAME_REGEX = "^[a-z0-9][a-z0-9_]{3,24}$"
 
 # Variables
@@ -1095,5 +1095,11 @@ def setup(bot: KoalaBot) -> None:
     Load this cog to the KoalaBot.
     :param bot: the bot client for KoalaBot
     """
-    bot.add_cog(TwitchAlert(bot))
-    logging.info("TwitchAlert is ready.")
+    if TWITCH_SECRET is None or TWITCH_CLIENT_ID is None:
+        logging.error("TwitchAlert not started. API keys not found in environment.")
+        print("TwitchAlert not started. API keys not found in environment.")
+        KoalaBot.database_manager.insert_extension("TwitchAlert", 0, False, False)
+    else:
+        bot.add_cog(TwitchAlert(bot))
+        logging.info("TwitchAlert is ready.")
+        print("TwitchAlert is ready.")

--- a/cogs/Verification.py
+++ b/cogs/Verification.py
@@ -25,8 +25,8 @@ from utils import KoalaDBManager
 
 # Constants
 load_dotenv()
-GMAIL_EMAIL = os.environ['GMAIL_EMAIL']
-GMAIL_PASSWORD = os.environ['GMAIL_PASSWORD']
+GMAIL_EMAIL = os.environ.get('GMAIL_EMAIL')
+GMAIL_PASSWORD = os.environ.get('GMAIL_PASSWORD')
 # Variables
 
 
@@ -51,7 +51,7 @@ class Verification(commands.Cog, name="Verify"):
     def __init__(self, bot, db_manager=None):
         self.bot = bot
         if not db_manager:
-            self.DBManager = KoalaDBManager.KoalaDBManager(KoalaBot.DATABASE_PATH, KoalaBot.DB_KEY)
+            self.DBManager = KoalaBot.database_manager
             self.set_up_tables()
             self.DBManager.insert_extension("Verify", 0, True, True)
         else:
@@ -435,11 +435,15 @@ This email is stored so you don't need to verify it multiple times across server
                 print(f"user with id {user_id} not found in {guild}")
 
 
-
 def setup(bot: KoalaBot) -> None:
     """
     Load this cog to the KoalaBot.
     :param bot: the bot client for KoalaBot
     """
-    bot.add_cog(Verification(bot))
-    print("Verification is ready.")
+    if GMAIL_EMAIL is None or GMAIL_PASSWORD is None:
+        print("Verification not started. API keys not found in environment.")
+        KoalaBot.database_manager.insert_extension("Verify", 0, False, False)
+    else:
+        bot.add_cog(Verification(bot))
+        print("Verification is ready.")
+

--- a/utils/KoalaDBManager.py
+++ b/utils/KoalaDBManager.py
@@ -153,6 +153,7 @@ class KoalaDBManager:
 
             self.db_execute_commit(sql_insert_extension, args=[extension_id, subscription_required, available, enabled])
 
+
     def extension_enabled(self, guild_id, extension_id):
         sql_select_extension = "SELECT extension_id " \
                                "FROM GuildExtensions " \
@@ -161,7 +162,7 @@ class KoalaDBManager:
         return ("All",) in result or (extension_id,) in result
 
     def give_guild_extension(self, guild_id, extension_id):
-        sql_check_extension_exists = """SELECT * FROM KoalaExtensions WHERE extension_id = ?"""
+        sql_check_extension_exists = """SELECT * FROM KoalaExtensions WHERE extension_id = ? and available = 1"""
         if len(self.db_execute_select(sql_check_extension_exists, args=[extension_id])) > 0 or extension_id == "All":
             sql_insert_guild_extension = """
             INSERT INTO GuildExtensions 
@@ -176,7 +177,10 @@ class KoalaDBManager:
         self.db_execute_commit(sql_remove_extension, args=[extension_id, guild_id], pass_errors=True)
 
     def get_enabled_guild_extensions(self, guild_id: int):
-        sql_select_enabled = "SELECT extension_id FROM GuildExtensions WHERE guild_id = ?"
+        sql_select_enabled = "SELECT GuildExtensions.extension_id FROM GuildExtensions, KoalaExtensions " \
+                             "WHERE KoalaExtensions.extension_id = GuildExtensions.extension_id " \
+                             "  AND guild_id = ? " \
+                             "  AND available = 1"
         return self.db_execute_select(sql_select_enabled, args=[guild_id], pass_errors=True)
 
     def get_all_available_guild_extensions(self, guild_id: int):


### PR DESCRIPTION
- KoalaBot can now be started without Twitch or Gmail keys (disabling TwitchAlert and Verify)
- Owner only commands fall back to bot owner if `BOT_OWNER` is not provided

close #80 