### PR TITLE
[Announce] Removed announce from help when not enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to KoalaBot will be documented in this file.
 A lot of these commands will only be available to administrators
 
 ## [Unreleased]
+### Announce
+##### Changed
+- Announce is hidden in help when not enabled
 
 ## [0.4.2] - 08-04-2021
 ### TwitchAlert

--- a/cogs/Announce.py
+++ b/cogs/Announce.py
@@ -122,6 +122,7 @@ class Announce(commands.Cog):
             embed.set_thumbnail(url=message.thumbnail)
         return embed
 
+    @commands.check(announce_is_enabled)
     @commands.group(name="announce")
     async def announce(self, ctx):
         """


### PR DESCRIPTION
Currently, announce is visible when not enabled in a server
![image](https://user-images.githubusercontent.com/30408869/119657227-8cc84500-be23-11eb-8d72-e357efec2db1.png)

This fixes the issue