### PR TITLE
Update Tests to use dpytest 0.5.0+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to KoalaBot will be documented in this file.
 A lot of these commands will only be available to administrators
 
 ## [Unreleased]
+### Other
+- Testing updated to use builders in dpytest 0.5.0
 
 ## [0.4.3] - 14-05-2021
 ### Announce

--- a/production-requirements.txt
+++ b/production-requirements.txt
@@ -6,7 +6,7 @@ certifi==2021.5.30
 chardet==4.0.0
 colorama==0.4.4
 discord.py==1.7.3
-dpytest==0.5.0
+dpytest==0.5.1
 emoji==1.2.0
 idna==2.10
 iniconfig==1.1.1

--- a/production-requirements.txt
+++ b/production-requirements.txt
@@ -6,7 +6,7 @@ certifi==2021.5.30
 chardet==4.0.0
 colorama==0.4.4
 discord.py==1.7.3
-dpytest==0.4.0
+dpytest==0.5.0
 emoji==1.2.0
 idna==2.10
 iniconfig==1.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ certifi==2021.5.30
 chardet==4.0.0
 colorama==0.4.4
 discord.py==1.7.3
-dpytest==0.5.0
+dpytest==0.5.1
 emoji==1.2.0
 idna==2.10
 iniconfig==1.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ certifi==2021.5.30
 chardet==4.0.0
 colorama==0.4.4
 discord.py==1.7.3
-dpytest==0.4.0
+dpytest==0.5.0
 emoji==1.2.0
 idna==2.10
 iniconfig==1.1.1

--- a/tests/test_Announce.py
+++ b/tests/test_Announce.py
@@ -71,10 +71,10 @@ async def test_create_legal_message(bot: discord.Client, announce_cog):
                     mock.AsyncMock(return_value=msg_mock)):
         await dpytest.message(KoalaBot.COMMAND_PREFIX + 'announce create',
                               channel=channel)
-        dpytest.verify_message("Please enter a message, I'll wait for 60 seconds, no rush.")
-        dpytest.verify_message(f"An announcement has been created for guild {guild.name}")
-        dpytest.verify_embed()
-        dpytest.verify_message()
+        assert dpytest.verify().message().content("Please enter a message, I'll wait for 60 seconds, no rush.")
+        assert dpytest.verify().message().content(f"An announcement has been created for guild {guild.name}")
+        assert dpytest.verify().message()
+        assert dpytest.verify().message()
         assert announce_cog.has_active_msg(guild.id)
         assert announce_cog.messages[guild.id].description == "testMessage"
         assert announce_cog.messages[guild.id].title == ""
@@ -93,8 +93,8 @@ async def test_create_illegal_message(announce_cog):
                     mock.AsyncMock(return_value=long_msg_mock)):
         await dpytest.message(KoalaBot.COMMAND_PREFIX + 'announce create',
                               channel=channel)
-        dpytest.verify_message("Please enter a message, I'll wait for 60 seconds, no rush.")
-        dpytest.verify_message("The content is more than 2000 characters long, and exceeds the limit")
+        assert dpytest.verify().message().content("Please enter a message, I'll wait for 60 seconds, no rush.")
+        assert dpytest.verify().message().content("The content is more than 2000 characters long, and exceeds the limit")
         assert not announce_cog.has_active_msg(guild.id)
 
 
@@ -108,10 +108,10 @@ async def test_create_multiple_message(announce_cog):
                     mock.AsyncMock(return_value=msg_mock)):
         await dpytest.message(KoalaBot.COMMAND_PREFIX + 'announce create',
                               channel=channel)
-        dpytest.verify_message("Please enter a message, I'll wait for 60 seconds, no rush.")
-        dpytest.verify_message(f"An announcement has been created for guild {guild.name}")
-        dpytest.verify_embed()
-        dpytest.verify_message()
+        assert dpytest.verify().message().content("Please enter a message, I'll wait for 60 seconds, no rush.")
+        assert dpytest.verify().message().content(f"An announcement has been created for guild {guild.name}")
+        assert dpytest.verify().message()
+        assert dpytest.verify().message()
         assert announce_cog.has_active_msg(guild.id)
         assert announce_cog.messages[guild.id].description == "testMessage"
         assert announce_cog.messages[guild.id].title == ""
@@ -121,7 +121,7 @@ async def test_create_multiple_message(announce_cog):
                         mock.AsyncMock(return_value=msg2_mock)):
             await dpytest.message(KoalaBot.COMMAND_PREFIX + 'announce create',
                                   channel=channel)
-            dpytest.verify_message("There is currently an active announcement being created, you can use 'k!announce cancel' "
+            assert dpytest.verify().message().content("There is currently an active announcement being created, you can use 'k!announce cancel' "
                                                                "or 'k!announce send' to complete it")
             assert announce_cog.has_active_msg(guild.id)
             assert announce_cog.messages[guild.id].description == "testMessage"
@@ -138,10 +138,10 @@ async def test_create_message_after_send_before_30_days(announce_cog):
                     mock.AsyncMock(return_value=msg_mock)):
         await dpytest.message(KoalaBot.COMMAND_PREFIX + 'announce create',
                               channel=channel)
-        dpytest.verify_message("Please enter a message, I'll wait for 60 seconds, no rush.")
-        dpytest.verify_message(f"An announcement has been created for guild {guild.name}")
-        dpytest.verify_embed()
-        dpytest.verify_message()
+        assert dpytest.verify().message().content("Please enter a message, I'll wait for 60 seconds, no rush.")
+        assert dpytest.verify().message().content(f"An announcement has been created for guild {guild.name}")
+        assert dpytest.verify().message()
+        assert dpytest.verify().message()
         assert announce_cog.has_active_msg(guild.id)
         assert announce_cog.messages[guild.id].description == "testMessage"
         assert announce_cog.messages[guild.id].title == ""
@@ -149,14 +149,14 @@ async def test_create_message_after_send_before_30_days(announce_cog):
         await dpytest.message(KoalaBot.COMMAND_PREFIX + 'announce send',
                               channel=channel)
         for _ in guild.members:
-            dpytest.verify_embed()
-        dpytest.verify_message("The announcement was made successfully")
+            assert dpytest.verify().message()
+        assert dpytest.verify().message().content("The announcement was made successfully")
         # try creating another announcement immediately
         with mock.patch('discord.client.Client.wait_for',
                         mock.AsyncMock(return_value=msg_mock)):
             await dpytest.message(KoalaBot.COMMAND_PREFIX + 'announce create',
                                   channel=channel)
-            dpytest.verify_message("You have recently sent an announcement and cannot use this function for 30 days")
+            assert dpytest.verify().message().content("You have recently sent an announcement and cannot use this function for 30 days")
             assert not announce_cog.has_active_msg(guild.id)
 
 
@@ -168,8 +168,8 @@ async def test_create_message_timeout():
                     mock.AsyncMock(return_value=None)):
         await dpytest.message(KoalaBot.COMMAND_PREFIX + 'announce create',
                               channel=channel)
-        dpytest.verify_message("Please enter a message, I'll wait for 60 seconds, no rush.")
-        dpytest.verify_message("Okay, I'll cancel the command.")
+        assert dpytest.verify().message().content("Please enter a message, I'll wait for 60 seconds, no rush.")
+        assert dpytest.verify().message().content("Okay, I'll cancel the command.")
 
 
 @pytest.mark.parametrize("command_word, prompt_message", [("changeTitle", "Please enter the new title, I'll wait for 60 seconds, no rush."),
@@ -190,8 +190,8 @@ async def test_other_timeout(command_word, prompt_message, announce_cog):
                     mock.AsyncMock(return_value=None)):
         await dpytest.message(KoalaBot.COMMAND_PREFIX + 'announce ' + command_word,
                               channel=channel)
-        dpytest.verify_message(prompt_message)
-        dpytest.verify_message("Okay, I'll cancel the command.")
+        assert dpytest.verify().message().content(prompt_message)
+        assert dpytest.verify().message().content("Okay, I'll cancel the command.")
 
 
 # testing functions with no active message
@@ -204,7 +204,7 @@ async def test_functions_no_active(command_word):
     channel: discord.TextChannel = guild.channels[0]
     await dpytest.message(KoalaBot.COMMAND_PREFIX + 'announce ' + command_word,
                           channel=channel)
-    dpytest.verify_message("There is currently no active announcement")
+    assert dpytest.verify().message().content("There is currently no active announcement")
 
 
 # testing functions with active message
@@ -222,8 +222,8 @@ async def test_change_title(announce_cog):
                     mock.AsyncMock(return_value=msg_mock)):
         await dpytest.message(KoalaBot.COMMAND_PREFIX + 'announce changeTitle',
                               channel=channel)
-        dpytest.verify_message("Please enter the new title, I'll wait for 60 seconds, no rush.")
-        dpytest.verify_embed()
+        assert dpytest.verify().message().content("Please enter the new title, I'll wait for 60 seconds, no rush.")
+        assert dpytest.verify().message()
         assert announce_cog.has_active_msg(guild.id)
         assert announce_cog.messages[guild.id].description == "testMessage"
         assert announce_cog.messages[guild.id].title == "testTitle"
@@ -243,8 +243,8 @@ async def test_change_message(announce_cog):
                     mock.AsyncMock(return_value=msg_mock)):
         await dpytest.message(KoalaBot.COMMAND_PREFIX + 'announce changeContent',
                               channel=channel)
-        dpytest.verify_message("Please enter the new message, I'll wait for 60 seconds, no rush.")
-        dpytest.verify_embed()
+        assert dpytest.verify().message().content("Please enter the new message, I'll wait for 60 seconds, no rush.")
+        assert dpytest.verify().message()
         assert announce_cog.has_active_msg(guild.id)
         assert announce_cog.messages[guild.id].description == "testMessage2"
         assert announce_cog.messages[guild.id].title == "This announcement is from " + guild.name
@@ -266,8 +266,8 @@ async def test_change_long_message(announce_cog):
                     mock.AsyncMock(return_value=msg_mock)):
         await dpytest.message(KoalaBot.COMMAND_PREFIX + 'announce changeContent',
                               channel=channel)
-        dpytest.verify_message("Please enter the new message, I'll wait for 60 seconds, no rush.")
-        dpytest.verify_message("The content is more than 2000 characters long, and exceeds the limit")
+        assert dpytest.verify().message().content("Please enter the new message, I'll wait for 60 seconds, no rush.")
+        assert dpytest.verify().message().content("The content is more than 2000 characters long, and exceeds the limit")
         assert announce_cog.has_active_msg(guild.id)
         assert announce_cog.messages[guild.id].description == "testMessage"
 
@@ -291,8 +291,8 @@ async def test_add_possible_role(number_of_roles, announce_cog):
                     mock.AsyncMock(return_value=msg_mock)):
         await dpytest.message(KoalaBot.COMMAND_PREFIX + 'announce add',
                               channel=channel)
-        dpytest.verify_message("Please enter the roles you want to tag separated by space, I'll wait for 60 seconds, no rush.")
-        dpytest.verify_message()
+        assert dpytest.verify().message().content("Please enter the roles you want to tag separated by space, I'll wait for 60 seconds, no rush.")
+        assert dpytest.verify().message()
         assert announce_cog.has_active_msg(guild.id)
         assert announce_cog.roles[guild.id] == role_id_list
 
@@ -309,8 +309,8 @@ async def test_add_non_existent_role(announce_cog):
                     mock.AsyncMock(return_value=msg_mock)):
         await dpytest.message(KoalaBot.COMMAND_PREFIX + 'announce add',
                               channel=channel)
-        dpytest.verify_message("Please enter the roles you want to tag separated by space, I'll wait for 60 seconds, no rush.")
-        dpytest.verify_message()
+        assert dpytest.verify().message().content("Please enter the roles you want to tag separated by space, I'll wait for 60 seconds, no rush.")
+        assert dpytest.verify().message()
         assert announce_cog.has_active_msg(guild.id)
         assert announce_cog.roles[guild.id] == []
 
@@ -329,8 +329,8 @@ async def test_add_same_role(announce_cog):
                     mock.AsyncMock(return_value=msg_mock)):
         await dpytest.message(KoalaBot.COMMAND_PREFIX + 'announce add',
                               channel=channel)
-        dpytest.verify_message("Please enter the roles you want to tag separated by space, I'll wait for 60 seconds, no rush.")
-        dpytest.verify_message()
+        assert dpytest.verify().message().content("Please enter the roles you want to tag separated by space, I'll wait for 60 seconds, no rush.")
+        assert dpytest.verify().message()
         assert announce_cog.has_active_msg(guild.id)
         assert announce_cog.roles[guild.id] == [roles[0].id]
 
@@ -348,8 +348,8 @@ async def test_remove_role_from_none(announce_cog):
                     mock.AsyncMock(return_value=msg_mock)):
         await dpytest.message(KoalaBot.COMMAND_PREFIX + 'announce remove',
                               channel=channel)
-        dpytest.verify_message("Please enter the roles you want to remove separated by space, I'll wait for 60 seconds, no rush.")
-        dpytest.verify_message()
+        assert dpytest.verify().message().content("Please enter the roles you want to remove separated by space, I'll wait for 60 seconds, no rush.")
+        assert dpytest.verify().message()
         assert announce_cog.has_active_msg(guild.id)
         assert announce_cog.roles[guild.id] == []
     msg_mock: discord.Message = dpytest.back.make_message("12345", author, channel)
@@ -357,8 +357,8 @@ async def test_remove_role_from_none(announce_cog):
                     mock.AsyncMock(return_value=msg_mock)):
         await dpytest.message(KoalaBot.COMMAND_PREFIX + 'announce remove',
                               channel=channel)
-        dpytest.verify_message("Please enter the roles you want to remove separated by space, I'll wait for 60 seconds, no rush.")
-        dpytest.verify_message()
+        assert dpytest.verify().message().content("Please enter the roles you want to remove separated by space, I'll wait for 60 seconds, no rush.")
+        assert dpytest.verify().message()
         assert announce_cog.has_active_msg(guild.id)
         assert announce_cog.roles[guild.id] == []
 
@@ -377,8 +377,8 @@ async def test_remove_existing_role(announce_cog):
                     mock.AsyncMock(return_value=msg_mock)):
         await dpytest.message(KoalaBot.COMMAND_PREFIX + 'announce remove',
                               channel=channel)
-        dpytest.verify_message("Please enter the roles you want to remove separated by space, I'll wait for 60 seconds, no rush.")
-        dpytest.verify_message()
+        assert dpytest.verify().message().content("Please enter the roles you want to remove separated by space, I'll wait for 60 seconds, no rush.")
+        assert dpytest.verify().message()
         assert announce_cog.has_active_msg(guild.id)
         assert announce_cog.roles[guild.id] == []
 
@@ -399,8 +399,8 @@ async def test_remove_non_existent_role(announce_cog):
                     mock.AsyncMock(return_value=msg_mock)):
         await dpytest.message(KoalaBot.COMMAND_PREFIX + 'announce remove',
                               channel=channel)
-        dpytest.verify_message("Please enter the roles you want to remove separated by space, I'll wait for 60 seconds, no rush.")
-        dpytest.verify_message()
+        assert dpytest.verify().message().content("Please enter the roles you want to remove separated by space, I'll wait for 60 seconds, no rush.")
+        assert dpytest.verify().message()
         assert announce_cog.has_active_msg(guild.id)
         assert announce_cog.roles[guild.id] == [roles[0].id]
 
@@ -435,8 +435,8 @@ async def test_preview_consistent(announce_cog):
     embed: discord.Embed = announce_cog.construct_embed(guild)
     await dpytest.message(KoalaBot.COMMAND_PREFIX + 'announce preview',
                           channel=channel)
-    dpytest.verify_embed(embed=embed)
-    dpytest.verify_message()
+    assert dpytest.verify().message().embed(embed=embed)
+    assert dpytest.verify().message()
 
 
 @pytest.mark.asyncio
@@ -449,7 +449,7 @@ async def test_cancel(announce_cog):
     assert guild.id in announce_cog.roles.keys()
     await dpytest.message(KoalaBot.COMMAND_PREFIX + 'announce cancel',
                           channel=channel)
-    dpytest.verify_message("The announcement was cancelled successfully")
+    assert dpytest.verify().message().content("The announcement was cancelled successfully")
     assert guild.id not in announce_cog.messages.keys()
     assert guild.id not in announce_cog.roles.keys()
 
@@ -476,17 +476,17 @@ async def test_announce_db_first_creation(announce_cog):
                     mock.AsyncMock(return_value=msg_mock)):
         await dpytest.message(KoalaBot.COMMAND_PREFIX + 'announce create',
                               channel=channel)
-        dpytest.verify_message("Please enter a message, I'll wait for 60 seconds, no rush.")
-        dpytest.verify_message(f"An announcement has been created for guild {guild.name}")
-        dpytest.verify_embed()
-        dpytest.verify_message()
+        assert dpytest.verify().message().content("Please enter a message, I'll wait for 60 seconds, no rush.")
+        assert dpytest.verify().message().content(f"An announcement has been created for guild {guild.name}")
+        assert dpytest.verify().message()
+        assert dpytest.verify().message()
         assert announce_cog.has_active_msg(guild.id)
         assert announce_cog.announce_database_manager.get_last_use_date(guild.id) is None
         await dpytest.message(KoalaBot.COMMAND_PREFIX + 'announce send',
                               channel=channel)
         for _ in guild.members:
-            dpytest.verify_embed()
-        dpytest.verify_message("The announcement was made successfully")
+            assert dpytest.verify().message()
+        assert dpytest.verify().message().content("The announcement was made successfully")
         assert int(time.time()) == announce_cog.announce_database_manager.get_last_use_date(guild.id)
 
 
@@ -506,18 +506,18 @@ async def test_announce_db_update_time_from_legal_use(announce_cog):
                     mock.AsyncMock(return_value=msg_mock)):
         await dpytest.message(KoalaBot.COMMAND_PREFIX + 'announce create',
                               channel=channel)
-        dpytest.verify_message("Please enter a message, I'll wait for 60 seconds, no rush.")
-        dpytest.verify_message(f"An announcement has been created for guild {guild.name}")
-        dpytest.verify_embed()
-        dpytest.verify_message()
+        assert dpytest.verify().message().content("Please enter a message, I'll wait for 60 seconds, no rush.")
+        assert dpytest.verify().message().content(f"An announcement has been created for guild {guild.name}")
+        assert dpytest.verify().message()
+        assert dpytest.verify().message()
         assert announce_cog.has_active_msg(guild.id)
         assert announce_cog.announce_database_manager.get_last_use_date(guild.id) == int(
             time.time()) - Announce.ANNOUNCE_SEPARATION_DAYS * 24 * 60 * 60 - 1
         await dpytest.message(KoalaBot.COMMAND_PREFIX + 'announce send',
                               channel=channel)
         for _ in guild.members:
-            dpytest.verify_embed()
-        dpytest.verify_message("The announcement was made successfully")
+            assert dpytest.verify().message()
+        assert dpytest.verify().message().content("The announcement was made successfully")
         assert int(time.time()) == announce_cog.announce_database_manager.get_last_use_date(guild.id)
 
 
@@ -536,10 +536,10 @@ async def test_announce_db_no_update_time_from_illegal_use(announce_cog):
                     mock.AsyncMock(return_value=msg_mock)):
         await dpytest.message(KoalaBot.COMMAND_PREFIX + 'announce create',
                               channel=channel)
-        dpytest.verify_message("You have recently sent an announcement and cannot use this function for 30 days")
+        assert dpytest.verify().message().content("You have recently sent an announcement and cannot use this function for 30 days")
         assert not announce_cog.has_active_msg(guild.id)
         assert announce_cog.announce_database_manager.get_last_use_date(guild.id) == current_time
         await dpytest.message(KoalaBot.COMMAND_PREFIX + 'announce send',
                               channel=channel)
-        dpytest.verify_message("There is currently no active announcement")
+        assert dpytest.verify().message().content("There is currently no active announcement")
         assert announce_cog.announce_database_manager.get_last_use_date(guild.id) == current_time

--- a/tests/test_BaseCog.py
+++ b/tests/test_BaseCog.py
@@ -34,11 +34,6 @@ def setup_is_dpytest():
     KoalaBot.is_dpytest = False
 
 
-def setup_function():
-    """ setup any state specific to the execution of the given module."""
-    print("Tests starting")
-
-
 # Test TwitchAlert
 @pytest.fixture(scope='function', autouse=True)
 async def base_cog(bot):
@@ -53,21 +48,21 @@ async def base_cog(bot):
 @pytest.mark.asyncio
 async def test_on_ready(base_cog: BaseCog.BaseCog):
     await base_cog.on_ready()
-    dpytest.verify_activity(discord.Activity(type=discord.ActivityType.playing,
+    assert dpytest.verify().activity().matches(discord.Activity(type=discord.ActivityType.playing,
                                              name=KoalaBot.COMMAND_PREFIX + "help" + KoalaBot.KOALA_PLUG))
 
 
 @pytest.mark.asyncio
 async def test_change_activity():
     await dpytest.message(KoalaBot.COMMAND_PREFIX + "change_activity watching you")
-    dpytest.verify_activity(discord.Activity(type=discord.ActivityType.watching, name="you" + KoalaBot.KOALA_PLUG))
-    dpytest.verify_message("I am now watching you")
+    assert dpytest.verify().activity().matches(discord.Activity(type=discord.ActivityType.watching, name="you" + KoalaBot.KOALA_PLUG))
+    assert dpytest.verify().message().content("I am now watching you")
 
 
 @pytest.mark.asyncio
 async def test_invalid_change_activity():
     await dpytest.message(KoalaBot.COMMAND_PREFIX + "change_activity oof you")
-    dpytest.verify_message("That is not a valid activity, sorry!\nTry 'playing' or 'watching'")
+    assert dpytest.verify().message().content("That is not a valid activity, sorry!\nTry 'playing' or 'watching'")
 
 
 def test_playing_new_discord_activity():
@@ -111,13 +106,13 @@ def test_invalid_new_discord_activity():
 @pytest.mark.asyncio
 async def test_ping(base_cog: BaseCog.BaseCog):
     await dpytest.message(KoalaBot.COMMAND_PREFIX + "ping")
-    dpytest.verify_message("Pong! 4ms")
+    assert dpytest.verify().message().content("Pong! 4ms")
 
 
 @pytest.mark.asyncio
 async def test_support():
     await dpytest.message(KoalaBot.COMMAND_PREFIX + "support")
-    dpytest.verify_message("Join our support server for more help! https://discord.gg/5etEjVd")
+    assert dpytest.verify().message().content("Join our support server for more help! https://discord.gg/5etEjVd")
 
 
 @pytest.mark.asyncio

--- a/tests/test_ColourRole.py
+++ b/tests/test_ColourRole.py
@@ -35,19 +35,6 @@ DBManager = ColourRoleDBManager(KoalaBot.database_manager)
 DBManager.create_tables()
 
 
-def setup_funsction():
-    """ setup any state specific to the execution of the given module."""
-    global role_colour_cog
-    global utils_cog
-    bot = commands.Bot(command_prefix=KoalaBot.COMMAND_PREFIX)
-    role_colour_cog = ColourRole.ColourRole(bot)
-    utils_cog = LastCtxCog.LastCtxCog(bot)
-    bot.add_cog(role_colour_cog)
-    bot.add_cog(utils_cog)
-    dpytest.configure(bot)
-    print("Tests starting")
-
-
 @pytest.fixture(autouse=True)
 def utils_cog(bot):
     utils_cog = LastCtxCog.LastCtxCog(bot)
@@ -494,12 +481,12 @@ async def test_custom_colour_check_failure():
     DBManager.add_colour_change_role_perms(guild.id, role.id)
     with pytest.raises(commands.CheckFailure):
         await dpytest.message(KoalaBot.COMMAND_PREFIX + "custom_colour ab1234")
-        await dpytest.verify_message("You don't have the required role to use this command.")
-        await dpytest.verify_message(assert_nothing=True)
+        assert dpytest.verify().message().content("You don't have the required role to use this command.")
+        assert dpytest.verify().message().nothing()
     with pytest.raises(commands.CheckFailure):
         await dpytest.message(KoalaBot.COMMAND_PREFIX + "custom_colour no")
-        await dpytest.verify_message("You don't have the required role to use this command.")
-        await dpytest.verify_message(assert_nothing=True)
+        assert dpytest.verify().message().content("You don't have the required role to use this command.")
+        assert dpytest.verify().message().nothing()
 
 
 @pytest.mark.asyncio
@@ -508,13 +495,13 @@ async def test_custom_colour_no_allowed_role():
         await dpytest.message(KoalaBot.COMMAND_PREFIX + "custom_colour ab1234")
         assert "KoalaBot[0xAB1234]" not in [role.name for role in dpytest.get_config().guilds[0].roles]
         assert "KoalaBot[0xAB1234]" not in [role.name for role in dpytest.get_config().members[0].roles]
-        await dpytest.verify_message("You don't have the required role to use this command.")
-        await dpytest.verify_message(assert_nothing=True)
+        assert dpytest.verify().message().content("You don't have the required role to use this command.")
+        assert dpytest.verify().message().nothing()
     with pytest.raises(commands.CheckFailure):
         await dpytest.message(KoalaBot.COMMAND_PREFIX + "custom_colour no")
         assert "KoalaBot[0xAB1234]" not in [role.name for role in dpytest.get_config().guilds[0].roles]
-        dpytest.verify_message("You don't have the required role to use this command.")
-        dpytest.verify_message(assert_nothing=True)
+        assert dpytest.verify().message().content("You don't have the required role to use this command.")
+        assert dpytest.verify().message().nothing()
 
 
 @pytest.mark.asyncio
@@ -525,9 +512,9 @@ async def test_custom_colour_no_no_colour_role():
     member: discord.Member = dpytest.get_config().members[0]
     await member.add_roles(role)
     await dpytest.message(KoalaBot.COMMAND_PREFIX + "custom_colour no", member=0)
-    dpytest.verify_message("Okay, removing your old custom colour role then, if you have one.")
-    dpytest.verify_message(f"{member.mention} you don't have any colour roles to remove.")
-    dpytest.verify_message(assert_nothing=True)
+    assert dpytest.verify().message().content("Okay, removing your old custom colour role then, if you have one.")
+    assert dpytest.verify().message().content(f"{member.mention} you don't have any colour roles to remove.")
+    assert dpytest.verify().message().nothing()
 
 
 @pytest.mark.asyncio
@@ -539,7 +526,7 @@ async def test_custom_colour_colour_is_protected():
     await member.add_roles(role)
     fail_colour = discord.Colour.from_rgb(255, 255, 255)
     await dpytest.message(KoalaBot.COMMAND_PREFIX + "custom_colour FEFEFE", member=0)
-    dpytest.verify_message(
+    assert dpytest.verify().message().content(
         f"Colour chosen was too close to an already protected colour {hex(fail_colour.value)}. Please choose a different colour.")
     assert "KoalaBot[0xFEFEFE]" not in [role.name for role in guild.roles]
 
@@ -552,7 +539,7 @@ async def test_custom_colour_invalid_colour_str():
     member: discord.Member = dpytest.get_config().members[0]
     await member.add_roles(role)
     await dpytest.message(KoalaBot.COMMAND_PREFIX + "custom_colour s34a21", member=0)
-    dpytest.verify_message(
+    assert dpytest.verify().message().content(
         f"Invalid colour string specified, make sure it's a valid colour hex.")
     assert len(member.roles) == 2
 
@@ -566,9 +553,9 @@ async def test_custom_colour_valid():
     await member.add_roles(role)
     await dpytest.message(KoalaBot.COMMAND_PREFIX + "custom_colour e34a21", member=0)
     colour_role = discord.utils.get(guild.roles, name=f"KoalaBot[0xE34A21]")
-    dpytest.verify_message(
+    assert dpytest.verify().message().content(
         f"Your new custom role colour is #E34A21, with the role {colour_role.mention}")
-    dpytest.verify_message(assert_nothing=True)
+    assert dpytest.verify().message().nothing()
     assert "KoalaBot[0xE34A21]" in [role.name for role in guild.roles]
     assert "KoalaBot[0xE34A21]" in [role.name for role in member.roles]
 

--- a/tests/test_IntroCog.py
+++ b/tests/test_IntroCog.py
@@ -153,12 +153,12 @@ async def test_on_member_join():
     await asyncio.sleep(0.25)
     welcome_message = IntroCog.get_guild_welcome_message(guild.id)
     await dpytest.member_join(1)
-    dpytest.verify_message(welcome_message)
+    assert dpytest.verify().message().content(welcome_message)
     DBManager.update_guild_welcome_message(guild.id, 'This is an updated welcome message.')
     await asyncio.sleep(0.25)
     welcome_message = IntroCog.get_guild_welcome_message(guild.id)
     await dpytest.member_join(1)
-    dpytest.verify_message(welcome_message)
+    assert dpytest.verify().message().content(welcome_message)
 
 
 @pytest.mark.asyncio
@@ -195,7 +195,7 @@ async def test_ask_for_confirmation(msg_content, is_invalid, expected):
     x = await IntroCog.ask_for_confirmation(message, channel)
     assert x == expected
     if is_invalid:
-        dpytest.verify_message()
+        assert dpytest.verify().message()
 
 
 @pytest.mark.parametrize("msg_content, expected",
@@ -215,9 +215,9 @@ async def test_send_welcome_message():
     msg_mock = dpytest.back.make_message('y', dpytest.get_config().members[0], dpytest.get_config().channels[0])
     with mock.patch('cogs.IntroCog.wait_for_message', mock.AsyncMock(return_value=msg_mock)):
         await dpytest.message(KoalaBot.COMMAND_PREFIX + "send_welcome_message")
-    dpytest.verify_message("This will DM 1 people. Are you sure you wish to do this? Y/N")
-    dpytest.verify_message("Okay, sending out the welcome message now.")
-    dpytest.verify_message(f"{IntroCog.DEFAULT_WELCOME_MESSAGE}\r\n{IntroCog.BASE_LEGAL_MESSAGE}")
+    assert dpytest.verify().message().content("This will DM 1 people. Are you sure you wish to do this? Y/N")
+    assert dpytest.verify().message().content("Okay, sending out the welcome message now.")
+    assert dpytest.verify().message().content(f"{IntroCog.DEFAULT_WELCOME_MESSAGE}\r\n{IntroCog.BASE_LEGAL_MESSAGE}")
 
 
 @pytest.mark.asyncio
@@ -225,19 +225,19 @@ async def test_send_welcome_message_cancelled():
     msg_mock = dpytest.back.make_message('n', dpytest.get_config().members[0], dpytest.get_config().channels[0])
     with mock.patch('cogs.IntroCog.wait_for_message', mock.AsyncMock(return_value=msg_mock)):
         await dpytest.message(KoalaBot.COMMAND_PREFIX + "send_welcome_message")
-    dpytest.verify_message("This will DM 1 people. Are you sure you wish to do this? Y/N")
-    dpytest.verify_message("Okay, I won't send out the welcome message then.")
-    dpytest.verify_message(assert_nothing=True)
+    assert dpytest.verify().message().content("This will DM 1 people. Are you sure you wish to do this? Y/N")
+    assert dpytest.verify().message().content("Okay, I won't send out the welcome message then.")
+    assert dpytest.verify().message().nothing()
 
 
 @pytest.mark.asyncio
 async def test_send_welcome_message_timeout():
     with mock.patch('cogs.IntroCog.wait_for_message', mock.AsyncMock(return_value=None)):
         await dpytest.message(KoalaBot.COMMAND_PREFIX + "send_welcome_message")
-        dpytest.verify_message("This will DM 1 people. Are you sure you wish to do this? Y/N")
-        dpytest.verify_message('Timed out.')
-        dpytest.verify_message("Okay, I won't send out the welcome message then.")
-        dpytest.verify_message(assert_nothing=True)
+        assert dpytest.verify().message().content("This will DM 1 people. Are you sure you wish to do this? Y/N")
+        assert dpytest.verify().message().content('Timed out.')
+        assert dpytest.verify().message().content("Okay, I won't send out the welcome message then.")
+        assert dpytest.verify().message().nothing()
 
 
 @pytest.mark.asyncio
@@ -249,11 +249,11 @@ async def test_cancel_update_welcome_message():
     with mock.patch('cogs.IntroCog.wait_for_message', mock.AsyncMock(return_value=msg_mock)):
         await dpytest.message(KoalaBot.COMMAND_PREFIX + "update_welcome_message " + new_message)
 
-    dpytest.verify_message(f"""Your current welcome message is:\n\r{old_message}""")
-    dpytest.verify_message(f"""Your new welcome message will be:\n\r{new_message}\n\r{IntroCog.BASE_LEGAL_MESSAGE}""" +
+    assert dpytest.verify().message().content(f"""Your current welcome message is:\n\r{old_message}""")
+    assert dpytest.verify().message().content(f"""Your new welcome message will be:\n\r{new_message}\n\r{IntroCog.BASE_LEGAL_MESSAGE}""" +
                            """\n\rWould you like to update the message? Y/N?""")
-    dpytest.verify_message("Okay, I won't update the welcome message then.")
-    dpytest.verify_message(assert_nothing=True)
+    assert dpytest.verify().message().content("Okay, I won't update the welcome message then.")
+    assert dpytest.verify().message().nothing()
     assert DBManager.fetch_guild_welcome_message(guild.id) != new_message
 
 
@@ -266,12 +266,12 @@ async def test_update_welcome_message():
     with mock.patch('cogs.IntroCog.wait_for_message', mock.AsyncMock(return_value=msg_mock)):
         await dpytest.message(KoalaBot.COMMAND_PREFIX + "update_welcome_message " + new_message)
 
-    dpytest.verify_message(f"""Your current welcome message is:\n\r{old_message}""")
-    dpytest.verify_message(f"""Your new welcome message will be:\n\r{new_message}\n\r{IntroCog.BASE_LEGAL_MESSAGE}""" +
+    assert dpytest.verify().message().content(f"""Your current welcome message is:\n\r{old_message}""")
+    assert dpytest.verify().message().content(f"""Your new welcome message will be:\n\r{new_message}\n\r{IntroCog.BASE_LEGAL_MESSAGE}""" +
                            """\n\rWould you like to update the message? Y/N?""")
-    dpytest.verify_message("Okay, updating the welcome message of the guild in the database now.")
-    dpytest.verify_message("Updated in the database, your new welcome message is this is a non default message.")
-    dpytest.verify_message(assert_nothing=True)
+    assert dpytest.verify().message().content("Okay, updating the welcome message of the guild in the database now.")
+    assert dpytest.verify().message().content("Updated in the database, your new welcome message is this is a non default message.")
+    assert dpytest.verify().message().nothing()
     assert DBManager.fetch_guild_welcome_message(guild.id) == new_message
 
 
@@ -284,8 +284,8 @@ async def test_update_welcome_message_too_long():
     msg_mock = dpytest.back.make_message('y', dpytest.get_config().members[0], dpytest.get_config().channels[0])
     with mock.patch('cogs.IntroCog.wait_for_message', mock.AsyncMock(return_value=msg_mock)):
         await dpytest.message(KoalaBot.COMMAND_PREFIX + "update_welcome_message " + new_message)
-    dpytest.verify_message("Your welcome message is too long to send, sorry. The maximum character limit is 1600.")
-    dpytest.verify_message(assert_nothing=True)
+    assert dpytest.verify().message().content("Your welcome message is too long to send, sorry. The maximum character limit is 1600.")
+    assert dpytest.verify().message().nothing()
     assert DBManager.fetch_guild_welcome_message(guild.id) != new_message
 
 
@@ -293,7 +293,7 @@ async def test_update_welcome_message_too_long():
 async def test_update_welcome_message_no_args():
     with pytest.raises(commands.MissingRequiredArgument):
         await dpytest.message(KoalaBot.COMMAND_PREFIX + "update_welcome_message")
-    dpytest.verify_message("Please put in a welcome message to update to.")
+    assert dpytest.verify().message().content("Please put in a welcome message to update to.")
 
 
 @pytest.mark.asyncio
@@ -301,7 +301,7 @@ async def test_view_welcome_message():
     guild = dpytest.get_config().guilds[0]
     old_message = IntroCog.get_guild_welcome_message(guild.id)
     await dpytest.message(KoalaBot.COMMAND_PREFIX + "welcomeViewMsg ")
-    dpytest.verify_message(f"""Your current welcome message is:\n\r{old_message}""")
+    assert dpytest.verify().message().content(f"""Your current welcome message is:\n\r{old_message}""")
 
 
 @pytest.mark.asyncio
@@ -313,12 +313,12 @@ async def test_update_welcome_message_timeout():
     with mock.patch('cogs.IntroCog.wait_for_message', mock.AsyncMock(return_value=None)):
         await dpytest.message(KoalaBot.COMMAND_PREFIX + "update_welcome_message " + new_message)
 
-    dpytest.verify_message(f"""Your current welcome message is:\n\r{old_message}""")
-    dpytest.verify_message(f"""Your new welcome message will be:\n\r{new_message}\n\r{IntroCog.BASE_LEGAL_MESSAGE}""" +
+    assert dpytest.verify().message().content(f"""Your current welcome message is:\n\r{old_message}""")
+    assert dpytest.verify().message().content(f"""Your new welcome message will be:\n\r{new_message}\n\r{IntroCog.BASE_LEGAL_MESSAGE}""" +
                            """\n\rWould you like to update the message? Y/N?""")
-    dpytest.verify_message("Timed out.")
-    dpytest.verify_message("Okay, I won't update the welcome message then.")
-    dpytest.verify_message(assert_nothing=True)
+    assert dpytest.verify().message().content("Timed out.")
+    assert dpytest.verify().message().content("Okay, I won't update the welcome message then.")
+    assert dpytest.verify().message().nothing()
     assert DBManager.fetch_guild_welcome_message(guild.id) != new_message
 
 

--- a/tests/test_KoalaBot.py
+++ b/tests/test_KoalaBot.py
@@ -109,7 +109,7 @@ async def test_dm_single_group_message():
     test_message = 'default message'
     test_member = dpytest.get_config().members[0]
     x = await KoalaBot.dm_group_message([test_member], test_message)
-    dpytest.verify_message(test_message)
+    assert dpytest.verify().message().content(test_message)
     assert x == 1
 
 
@@ -120,8 +120,8 @@ async def test_dm_plural_group_message():
     test_member_2 = await dpytest.member_join()
     await dpytest.empty_queue()
     x = await KoalaBot.dm_group_message([test_member, test_member_2], test_message)
-    dpytest.verify_message(test_message)
-    dpytest.verify_message(test_message)
+    assert dpytest.verify().message().content(test_message)
+    assert dpytest.verify().message().content(test_message)
     assert x == 2
 
 
@@ -129,7 +129,7 @@ async def test_dm_plural_group_message():
 async def test_dm_empty_group_message():
     test_message = 'this should not be sent'
     x = await KoalaBot.dm_group_message([], test_message)
-    dpytest.verify_message(assert_nothing=True)
+    assert dpytest.verify().message().nothing()
     assert x == 0
 
 

--- a/tests/test_ReactForRole.py
+++ b/tests/test_ReactForRole.py
@@ -448,14 +448,14 @@ async def test_prompt_for_input_str(msg_content,utils_cog,rfr_cog):
         with mock.patch('utils.KoalaUtils.wait_for_message',
                         mock.AsyncMock(return_value=(None, channel))):
             result = await rfr_cog.prompt_for_input(ctx, "test")
-            dpytest.verify_message("Please enter test so I can progress further. I'll wait 60 seconds, don't worry.")
-            dpytest.verify_message("Okay, I'll cancel the command.")
+            assert dpytest.verify().message().content("Please enter test so I can progress further. I'll wait 60 seconds, don't worry.")
+            assert dpytest.verify().message().content("Okay, I'll cancel the command.")
             assert not result
     else:
         msg: discord.Message = dpytest.back.make_message(content=msg_content, author=author, channel=channel)
         with mock.patch('utils.KoalaUtils.wait_for_message', mock.AsyncMock(return_value=(msg, None))):
             result = await rfr_cog.prompt_for_input(ctx, "test")
-            dpytest.verify_message("Please enter test so I can progress further. I'll wait 60 seconds, don't worry.")
+            assert dpytest.verify().message().content("Please enter test so I can progress further. I'll wait 60 seconds, don't worry.")
             assert result == msg_content
 
 
@@ -478,7 +478,7 @@ async def test_prompt_for_input_attachment(rfr_cog, utils_cog):
     message: discord.Message = discord.Message(state=dpytest.back.get_state(), channel=channel, data=message_dict)
     with mock.patch('utils.KoalaUtils.wait_for_message', mock.AsyncMock(return_value=(message, channel))):
         result = await rfr_cog.prompt_for_input(ctx, "test")
-        dpytest.verify_message("Please enter test so I can progress further. I'll wait 60 seconds, don't worry.")
+        assert dpytest.verify().message().content("Please enter test so I can progress further. I'll wait 60 seconds, don't worry.")
         assert isinstance(result, discord.Attachment)
         assert result.url == attach.url
 
@@ -620,27 +620,27 @@ async def test_rfr_create_message(bot):
                     with mock.patch('discord.Message.delete') as mock_delete:
                         await dpytest.message(KoalaBot.COMMAND_PREFIX + "rfr createMessage")
                         mock_edit_channel_perms.assert_called_once_with(guild, embed_channel)
-                        dpytest.verify_message(
+                        assert dpytest.verify().message().content(
                             "Okay, this will create a new react for role message in a channel of your choice."
                             "\nNote: The channel you specify will have its permissions edited to make it such that the "
                             "@ everyone role is unable to add new reactions to messages, they can only reaction with "
                             "existing ones. Please keep this in mind, or setup another channel entirely for this.")
-                        dpytest.verify_message("This should be a thing sent in the right channel.")
-                        dpytest.verify_message(
+                        assert dpytest.verify().message().content("This should be a thing sent in the right channel.")
+                        assert dpytest.verify().message().content(
                             "Okay, what would you like the title of the react for role message to be? Please enter within 60 seconds.")
-                        dpytest.verify_message(
+                        assert dpytest.verify().message().content(
                             "Okay, didn't receive a title. Do you actually want to continue? Send anything to confirm this.")
-                        dpytest.verify_message(
+                        assert dpytest.verify().message().content(
                             "Okay, I'll just put in a default value for you, you can edit it later by using the k!rfr edit commands.")
-                        dpytest.verify_message(
+                        assert dpytest.verify().message().content(
                             "Okay, the title of the message will be \"React for Role\". What do you want the description to be? I'll wait 60 seconds, don't worry")
-                        dpytest.verify_message(
+                        assert dpytest.verify().message().content(
                             "Okay, didn't receive a description. Do you actually want to continue? Send anything to confirm this.")
-                        dpytest.verify_message(
+                        assert dpytest.verify().message().content(
                             "Okay, I'll just put in a default value for you, you can edit it later by using the k!rfr edit command.")
-                        dpytest.verify_message(
+                        assert dpytest.verify().message().content(
                             "Okay, the description of the message will be \"Roles below!\".\n Okay, I'll create the react for role message now.")
-                        dpytest.verify_embed()
+                        assert dpytest.verify().message()
                         msg = dpytest.sent_queue.get_nowait()
                         assert "You can use the other k!rfr subcommands to change the message and add functionality as required." in msg.content
                         mock_delete.assert_called_once()
@@ -661,11 +661,11 @@ async def test_rfr_delete_message():
             with mock.patch('discord.Message.delete') as mock_msg_delete:
                 await dpytest.message(KoalaBot.COMMAND_PREFIX + "rfr deleteMessage")
                 mock_msg_delete.assert_called_once()
-                dpytest.verify_message(
+                assert dpytest.verify().message().content(
                     "Okay, this will delete an existing react for role message. I'll need some details first though.")
-                dpytest.verify_message()
-                dpytest.verify_message()
-                dpytest.verify_message()
+                assert dpytest.verify().message()
+                assert dpytest.verify().message()
+                assert dpytest.verify().message()
                 assert not independent_get_guild_rfr_message(guild.id, channel.id, msg_id)
 
 
@@ -687,9 +687,9 @@ async def test_rfr_edit_description():
             with mock.patch('cogs.ReactForRole.ReactForRole.get_embed_from_message', return_value=embed):
                 await dpytest.message(KoalaBot.COMMAND_PREFIX + "rfr edit description")
                 assert embed.description == 'new description'
-                dpytest.verify_message()
-                dpytest.verify_message()
-                dpytest.verify_message()
+                assert dpytest.verify().message()
+                assert dpytest.verify().message()
+                assert dpytest.verify().message()
 
 
 @pytest.mark.asyncio
@@ -710,9 +710,9 @@ async def test_rfr_edit_title():
             with mock.patch('cogs.ReactForRole.ReactForRole.get_embed_from_message', return_value=embed):
                 await dpytest.message(KoalaBot.COMMAND_PREFIX + "rfr edit title")
                 assert embed.title == 'new title'
-                dpytest.verify_message()
-                dpytest.verify_message()
-                dpytest.verify_message()
+                assert dpytest.verify().message()
+                assert dpytest.verify().message()
+                assert dpytest.verify().message()
 
 
 @pytest.mark.asyncio
@@ -822,11 +822,11 @@ async def test_rfr_edit_inline_all(arg):
             with mock.patch("cogs.ReactForRole.ReactForRole.get_embed_from_message", side_effects=[embed1, embed2]):
                 with mock.patch('discord.Embed.set_field_at') as mock_call:
                     await dpytest.message("k!rfr edit inline")
-                    dpytest.verify_message()
-                    dpytest.verify_message()
-                    dpytest.verify_message(
+                    assert dpytest.verify().message()
+                    assert dpytest.verify().message()
+                    assert dpytest.verify().message().content(
                         "Keep in mind that this process may take a while if you have a lot of RFR messages on your server.")
-                    dpytest.verify_message("Okay, the process should be finished now. Please check.")
+                    assert dpytest.verify().message().content("Okay, the process should be finished now. Please check.")
 
 
 @pytest.mark.skip("Unsupported API Calls")

--- a/tests/test_TextFilter.py
+++ b/tests/test_TextFilter.py
@@ -70,27 +70,27 @@ async def tf_cog(bot):
     return tf_cog
 
 def assertBannedWarning(word):
-    dpytest.verify_message("Watch your language! Your message: '*" + word + "*' in " + dpytest.get_config().guilds[0].channels[0].mention + " has been deleted by KoalaBot.")
+    assert dpytest.verify().message().content("Watch your language! Your message: '*" + word + "*' in " + dpytest.get_config().guilds[0].channels[0].mention + " has been deleted by KoalaBot.")
 
 
 def assertRiskyWarning(word):
-    dpytest.verify_message("Watch your language! Your message: '*" + word + "*' in " + dpytest.get_config().guilds[0].channels[0].mention + " contains a 'risky' word. This is a warning.")
+    assert dpytest.verify().message().content("Watch your language! Your message: '*" + word + "*' in " + dpytest.get_config().guilds[0].channels[0].mention + " contains a 'risky' word. This is a warning.")
 
 
 def assertEmailWarning(word):
-    dpytest.verify_message("Be careful! Your message: '*"+word+"*' in "+dpytest.get_config().guilds[0].channels[0].mention+" includes personal information and has been deleted by KoalaBot.")
+    assert dpytest.verify().message().content("Be careful! Your message: '*"+word+"*' in "+dpytest.get_config().guilds[0].channels[0].mention+" includes personal information and has been deleted by KoalaBot.")
 
 
 def assertFilteredConfirmation(word, type):
-    dpytest.verify_message("*"+word+"* has been filtered as **"+type+"**.")
+    assert dpytest.verify().message().content("*"+word+"* has been filtered as **"+type+"**.")
 
 
 def assertNewIgnore(id):
-    dpytest.verify_message("New ignore added: "+id)
+    assert dpytest.verify().message().content("New ignore added: "+id)
 
 
 def assertRemoveIgnore(id):
-    dpytest.verify_message("Ignore removed: "+id)
+    assert dpytest.verify().message().content("Ignore removed: "+id)
 
 def createNewModChannelEmbed(channel):
     embed = discord.Embed()
@@ -201,8 +201,8 @@ async def test_normal_filter_does_not_recognise_regex():
     assertFilteredConfirmation("^verify [a-zA-Z0-9]+@soton.ac.uk$", "banned")
 
     await dpytest.message("verify abc@soton.ac.uk")
-    dpytest.verify_message(assert_nothing=True)
-
+    assert dpytest.verify().message().nothing()
+    
 @pytest.mark.asyncio()
 async def test_filter_various_emails_with_regex(tf_cog):
     await dpytest.message(KoalaBot.COMMAND_PREFIX + r"filter_regex [a-z0-9]+[\._]?[a-z0-9]+[@]+[herts]+[.ac.uk]")
@@ -218,11 +218,11 @@ async def test_filter_various_emails_with_regex(tf_cog):
 
     # Should not warn
     await dpytest.message("hey herts.ac.uk")
-    dpytest.verify_message(assert_nothing=True)
+    assert dpytest.verify().message().nothing()
 
     # Should not warn
     await dpytest.message("hey stefan@herts")
-    dpytest.verify_message(assert_nothing=True)
+    assert dpytest.verify().message().nothing()
 
     cleanup(dpytest.get_config().guilds[0].id, tf_cog)
 
@@ -235,7 +235,7 @@ async def test_unfilter_word_correct_database(tf_cog):
     await dpytest.message(KoalaBot.COMMAND_PREFIX + "unfilter_word unfilterboi")
     
     assert len(tf_cog.tf_database_manager.database_manager.db_execute_select(f"SELECT filtered_text FROM TextFilter WHERE filtered_text = 'unfilterboi';")) == old - 1  
-    dpytest.verify_message("*unfilterboi* has been unfiltered.")
+    assert dpytest.verify().message().content("*unfilterboi* has been unfiltered.")
     cleanup(dpytest.get_config().guilds[0].id, tf_cog)
 
 @pytest.mark.asyncio()
@@ -257,14 +257,14 @@ async def test_list_filtered_words(tf_cog):
 
     await dpytest.message(KoalaBot.COMMAND_PREFIX + "check_filtered_words")
     assert_embed = filteredWordsEmbed(['listing1','listing2'],['banned','risky'], ['0','0'])
-    dpytest.verify_embed(embed=assert_embed)
+    assert dpytest.verify().message().embed(embed=assert_embed)
     cleanup(dpytest.get_config().guilds[0].id, tf_cog)
 
 @pytest.mark.asyncio()
 async def test_list_filtered_words_empty(tf_cog):
     await dpytest.message(KoalaBot.COMMAND_PREFIX + "check_filtered_words")
     assert_embed = filteredWordsEmbed([],[],[])
-    dpytest.verify_embed(embed=assert_embed)
+    assert dpytest.verify().message().embed(embed=assert_embed)
     cleanup(dpytest.get_config().guilds[0].id, tf_cog)
 
 @pytest.mark.asyncio()
@@ -274,7 +274,7 @@ async def test_add_mod_channel(tf_cog):
 
     await dpytest.message(KoalaBot.COMMAND_PREFIX + "setupModChannel "+str(channel.id))
     assert_embed = createNewModChannelEmbed(channel)
-    dpytest.verify_embed(embed=assert_embed)
+    assert dpytest.verify().message().embed(embed=assert_embed)
     cleanup(dpytest.get_config().guilds[0].id, tf_cog)
 
 
@@ -290,7 +290,7 @@ async def test_add_mod_channel_tag(text_filter_db_manager, tf_cog):
 
     await dpytest.message(KoalaBot.COMMAND_PREFIX + "setupModChannel <#"+str(channel.id)+">")
     assert_embed = createNewModChannelEmbed(channel)
-    dpytest.verify_embed(embed=assert_embed)
+    assert dpytest.verify().message().embed(embed=assert_embed)
 
     result = text_filter_db_manager.database_manager.db_execute_select("SELECT channel_id FROM TextFilterModeration WHERE guild_id = ?;", args=[channel.guild.id])
     assert is_int(result[0][0])
@@ -321,11 +321,11 @@ async def test_remove_mod_channel(tf_cog):
 
     await dpytest.message(KoalaBot.COMMAND_PREFIX + "setupModChannel "+channelId)
     assert_embed = createNewModChannelEmbed(channel)
-    dpytest.verify_embed(embed=assert_embed)
+    assert dpytest.verify().message().embed(embed=assert_embed)
 
     await dpytest.message(KoalaBot.COMMAND_PREFIX + "removeModChannel "+channelId)
     assert_embed = removeModChannelEmbed(channel)
-    dpytest.verify_embed(embed=assert_embed)
+    assert dpytest.verify().message().embed(embed=assert_embed)
     cleanup(dpytest.get_config().guilds[0].id, tf_cog)
 
 @pytest.mark.asyncio()
@@ -350,11 +350,11 @@ async def test_list_channels(tf_cog):
 
     await dpytest.message(KoalaBot.COMMAND_PREFIX + "setupModChannel "+str(channel.id))
     assert_embed = createNewModChannelEmbed(channel)
-    dpytest.verify_embed(embed=assert_embed)
+    assert dpytest.verify().message().embed(embed=assert_embed)
 
     await dpytest.message(KoalaBot.COMMAND_PREFIX + "listModChannels")
     assert_embed = listModChannelEmbed([channel])
-    dpytest.verify_embed(embed=assert_embed)
+    assert dpytest.verify().message().embed(embed=assert_embed)
     cleanup(dpytest.get_config().guilds[0].id, tf_cog)
 
 @pytest.mark.asyncio()
@@ -366,15 +366,15 @@ async def test_list_multiple_channels(tf_cog):
 
     await dpytest.message(KoalaBot.COMMAND_PREFIX + "setupModChannel "+str(channel1.id))
     assert_embed = createNewModChannelEmbed(channel1)
-    dpytest.verify_embed(embed=assert_embed)
+    assert dpytest.verify().message().embed(embed=assert_embed)
 
     await dpytest.message(KoalaBot.COMMAND_PREFIX + "setupModChannel "+str(channel2.id))
     assert_embed = createNewModChannelEmbed(channel2)
-    dpytest.verify_embed(embed=assert_embed)
+    assert dpytest.verify().message().embed(embed=assert_embed)
 
     await dpytest.message(KoalaBot.COMMAND_PREFIX + "listModChannels")
     assert_embed = listModChannelEmbed([channel1,channel2])
-    dpytest.verify_embed(embed=assert_embed)
+    assert dpytest.verify().message().embed(embed=assert_embed)
     cleanup(dpytest.get_config().guilds[0].id, tf_cog)
 
 @pytest.mark.asyncio()

--- a/tests/test_TwitchAlert.py
+++ b/tests/test_TwitchAlert.py
@@ -111,7 +111,7 @@ async def test_edit_default_message_default_from_none(twitch_cog):
                                              f"Default Message: {TwitchAlert.DEFAULT_MESSAGE}")
 
     await dpytest.message(KoalaBot.COMMAND_PREFIX + f"edit_default_message {this_channel.id}")
-    dpytest.verify_embed(embed=assert_embed)
+    assert dpytest.verify().message().embed(embed=assert_embed)
 
 
 @mock.patch("utils.KoalaUtils.random_id", mock.MagicMock(return_value=7357))
@@ -124,7 +124,7 @@ async def test_edit_default_message_existing(twitch_cog):
                                              "Default Message: {user} is bad")
 
     await dpytest.message(KoalaBot.COMMAND_PREFIX + "edit_default_message " + str(this_channel.id) + " {user} is bad")
-    dpytest.verify_embed(embed=assert_embed)
+    assert dpytest.verify().message().embed(embed=assert_embed)
 
 
 @pytest.mark.asyncio(order=3)
@@ -137,7 +137,7 @@ async def test_add_user_to_twitch_alert(twitch_cog):
 
     await dpytest.message(
         f"{KoalaBot.COMMAND_PREFIX}add_user_to_twitch_alert {dpytest.get_config().channels[0].id} monstercat")
-    dpytest.verify_embed(embed=assert_embed)
+    assert dpytest.verify().message().embed(embed=assert_embed)
 
 
 @pytest.mark.asyncio(order=3)
@@ -152,7 +152,7 @@ async def test_add_user_to_twitch_alert_wrong_guild(twitch_cog):
     await dpytest.message(
         f"{KoalaBot.COMMAND_PREFIX}add_user_to_twitch_alert {dpytest.get_config().channels[0].id} monstercat",
         channel=-1, member=member)
-    dpytest.verify_embed(
+    assert dpytest.verify().message().embed(
         embed=TwitchAlert.error_embed("The channel ID provided is either invalid, or not in this server."))
 
 
@@ -176,7 +176,7 @@ async def test_add_user_to_twitch_alert_custom_message(twitch_cog):
     await dpytest.message(
         f"{KoalaBot.COMMAND_PREFIX}add_user_to_twitch_alert {channel.id} monstercat {test_custom_message}", channel=-1,
         member=member)
-    dpytest.verify_embed(embed=assert_embed)
+    assert dpytest.verify().message().embed(embed=assert_embed)
 
     sql_check_updated_server = f"SELECT custom_message FROM UserInTwitchAlert WHERE twitch_username='monstercat' AND channel_id={channel.id}"
     assert twitch_cog.ta_database_manager.database_manager.db_execute_select(sql_check_updated_server) == [
@@ -210,7 +210,7 @@ async def test_remove_user_from_twitch_alert_with_message(twitch_cog):
     new_embed = discord.Embed(title="Removed User from Twitch Alert", colour=KOALA_GREEN,
                               description=f"Channel: {channel.id}\n"
                                           f"User: monstercat")
-    dpytest.verify_embed(new_embed)
+    assert dpytest.verify().message().embed(new_embed)
     assert twitch_cog.ta_database_manager.database_manager.db_execute_select(sql_check_updated_server) == []
     pass
 
@@ -227,7 +227,7 @@ async def test_remove_user_from_twitch_alert_wrong_guild(twitch_cog):
     await dpytest.message(
         f"{KoalaBot.COMMAND_PREFIX}remove_user_from_twitch_alert {dpytest.get_config().channels[0].id} monstercat",
         channel=-1, member=member)
-    dpytest.verify_embed(
+    assert dpytest.verify().message().embed(
         embed=TwitchAlert.error_embed("The channel ID provided is either invalid, or not in this server."))
 
 
@@ -248,7 +248,7 @@ async def test_add_team_to_twitch_alert(twitch_cog):
     # Creates Twitch Alert
     await dpytest.message(f"{KoalaBot.COMMAND_PREFIX}add_team_to_twitch_alert {channel.id} faze", channel=-1,
                           member=member)
-    dpytest.verify_embed(assert_embed)
+    assert dpytest.verify().message().embed(assert_embed)
 
 
 @pytest.mark.asyncio()
@@ -268,7 +268,7 @@ async def test_add_team_to_twitch_alert_with_message(twitch_cog):
     # Creates Twitch Alert
     await dpytest.message(f"{KoalaBot.COMMAND_PREFIX}add_team_to_twitch_alert {channel.id} faze wooo message",
                           channel=-1, member=member)
-    dpytest.verify_embed(assert_embed)
+    assert dpytest.verify().message().embed(assert_embed)
 
 
 @pytest.mark.asyncio()
@@ -284,7 +284,7 @@ async def test_add_team_to_twitch_alert_wrong_guild(twitch_cog):
     await dpytest.message(
         f"{KoalaBot.COMMAND_PREFIX}add_team_to_twitch_alert {dpytest.get_config().channels[0].id} faze ", channel=-1,
         member=member)
-    dpytest.verify_embed(
+    assert dpytest.verify().message().embed(
         embed=TwitchAlert.error_embed("The channel ID provided is either invalid, or not in this server."))
 
 
@@ -310,7 +310,7 @@ async def test_remove_team_from_twitch_alert_with_message(twitch_cog):
     new_embed = discord.Embed(title="Removed Team from Twitch Alert", colour=KOALA_GREEN,
                               description=f"Channel: {channel.id}\n"
                                           f"Team: faze")
-    dpytest.verify_embed(new_embed)
+    assert dpytest.verify().message().embed(new_embed)
     pass
 
 
@@ -326,7 +326,7 @@ async def test_remove_team_from_twitch_alert_wrong_guild(twitch_cog):
     await dpytest.message(
         f"{KoalaBot.COMMAND_PREFIX}remove_team_from_twitch_alert {dpytest.get_config().channels[0].id} monstercat",
         channel=-1, member=member)
-    dpytest.verify_embed(
+    assert dpytest.verify().message().embed(
         embed=TwitchAlert.error_embed("The channel ID provided is either invalid, or not in this server."))
 
 
@@ -361,7 +361,7 @@ async def test_loop_check_live(twitch_cog):
     await dpytest.empty_queue()
     twitch_cog.start_loop()
     await asyncio.sleep(10)
-    dpytest.verify_embed(expected_embed)
+    assert dpytest.verify().message().embed(expected_embed)
 
 
 @pytest.mark.asyncio

--- a/tests/test_Voting.py
+++ b/tests/test_Voting.py
@@ -78,7 +78,7 @@ async def test_discord_create_vote():
     config = dpytest.get_config()
     guild = config.guilds[0]
     await dpytest.message(f"{KoalaBot.COMMAND_PREFIX}vote create Test Vote")
-    dpytest.verify_message(f"Vote titled `Test Vote` created for guild {guild.name}. Use `{KoalaBot.COMMAND_PREFIX}help vote` to see how to configure it.")
+    assert dpytest.verify().message().content(f"Vote titled `Test Vote` created for guild {guild.name}. Use `{KoalaBot.COMMAND_PREFIX}help vote` to see how to configure it.")
     in_db = db_manager.db_execute_select("SELECT * FROM Votes")[0]
     assert in_db
     assert in_db[1] == guild.members[0].id
@@ -91,14 +91,14 @@ async def test_discord_create_vote_wrong():
     guild = config.guilds[0]
     db_manager.db_execute_commit("INSERT INTO Votes VALUES (?, ?, ?, ?, ?, ?, ?)", (111, guild.members[0].id, guild.id, "Test Vote", None, None, None))
     await dpytest.message(f"{KoalaBot.COMMAND_PREFIX}vote create Test Vote")
-    dpytest.verify_message("You already have a vote with title Test Vote sent!")
+    assert dpytest.verify().message().content("You already have a vote with title Test Vote sent!")
     await dpytest.message(f"{KoalaBot.COMMAND_PREFIX}vote create aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
-    dpytest.verify_message("Title too long")
+    assert dpytest.verify().message().content("Title too long")
     await dpytest.message(f"{KoalaBot.COMMAND_PREFIX}vote create Test Vote 2")
-    dpytest.verify_message(
+    assert dpytest.verify().message().content(
         f"Vote titled `Test Vote 2` created for guild {guild.name}. Use `{KoalaBot.COMMAND_PREFIX}help vote` to see how to configure it.")
     await dpytest.message(f"{KoalaBot.COMMAND_PREFIX}vote create Test Vote 3")
-    dpytest.verify_message(f"You already have an active vote in {guild.name}. Please send that with `{KoalaBot.COMMAND_PREFIX}vote send` before creating a new one.")
+    assert dpytest.verify().message().content(f"You already have an active vote in {guild.name}. Please send that with `{KoalaBot.COMMAND_PREFIX}vote send` before creating a new one.")
 
 
 @pytest.mark.asyncio
@@ -106,14 +106,14 @@ async def test_discord_vote_add_and_remove_role(cog):
     config = dpytest.get_config()
     guild = config.guilds[0]
     await dpytest.message(f"{KoalaBot.COMMAND_PREFIX}vote create Test Vote")
-    dpytest.verify_message(
+    assert dpytest.verify().message().content(
         f"Vote titled `Test Vote` created for guild {guild.name}. Use `{KoalaBot.COMMAND_PREFIX}help vote` to see how to configure it.")
     await dpytest.message(f"{KoalaBot.COMMAND_PREFIX}vote addRole {guild.roles[0].id}")
-    dpytest.verify_message(f"Vote will be sent to those with the {guild.roles[0].name} role")
+    assert dpytest.verify().message().content(f"Vote will be sent to those with the {guild.roles[0].name} role")
     vote = cog.vote_manager.get_configuring_vote(guild.members[0].id)
     assert guild.roles[0].id in vote.target_roles
     await dpytest.message(f"{KoalaBot.COMMAND_PREFIX}vote removeRole {guild.roles[0].id}")
-    dpytest.verify_message(f"Vote will no longer be sent to those with the {guild.roles[0].name} role")
+    assert dpytest.verify().message().content(f"Vote will no longer be sent to those with the {guild.roles[0].name} role")
     assert guild.roles[0].id not in vote.target_roles
 
 
@@ -122,27 +122,27 @@ async def test_discord_set_chair():
     config = dpytest.get_config()
     guild = config.guilds[0]
     await dpytest.message(f"{KoalaBot.COMMAND_PREFIX}vote create Test Vote")
-    dpytest.verify_message(
+    assert dpytest.verify().message().content(
         f"Vote titled `Test Vote` created for guild {guild.name}. Use `{KoalaBot.COMMAND_PREFIX}help vote` to see how to configure it.")
     await dpytest.message(f"{KoalaBot.COMMAND_PREFIX}vote setChair {guild.members[0].id}")
-    dpytest.verify_message(f"You have been selected as the chair for vote titled Test Vote")
-    dpytest.verify_message(f"Set chair to {guild.members[0].name}")
+    assert dpytest.verify().message().content(f"You have been selected as the chair for vote titled Test Vote")
+    assert dpytest.verify().message().content(f"Set chair to {guild.members[0].name}")
     await dpytest.message(f"{KoalaBot.COMMAND_PREFIX}vote setChair")
-    dpytest.verify_message("Results will be sent to the channel vote is closed in")
+    assert dpytest.verify().message().content("Results will be sent to the channel vote is closed in")
 
 @pytest.mark.asyncio
 async def test_discord_add_remove_option():
     config = dpytest.get_config()
     guild = config.guilds[0]
     await dpytest.message(f"{KoalaBot.COMMAND_PREFIX}vote create Test Vote")
-    dpytest.verify_message(
+    assert dpytest.verify().message().content(
         f"Vote titled `Test Vote` created for guild {guild.name}. Use `{KoalaBot.COMMAND_PREFIX}help vote` to see how to configure it.")
     await dpytest.message(f"{KoalaBot.COMMAND_PREFIX}vote addOption test+test")
-    dpytest.verify_message("Option test with description test added to vote")
+    assert dpytest.verify().message().content("Option test with description test added to vote")
     await dpytest.message(f"{KoalaBot.COMMAND_PREFIX}vote addOption testtest")
-    dpytest.verify_message("Example usage: k!vote addOption option title+option description")
+    assert dpytest.verify().message().content("Example usage: k!vote addOption option title+option description")
     await dpytest.message(f"{KoalaBot.COMMAND_PREFIX}vote removeOption 1")
-    dpytest.verify_message("Option number 1 removed")
+    assert dpytest.verify().message().content("Option number 1 removed")
 
 
 @pytest.mark.asyncio
@@ -150,10 +150,10 @@ async def test_discord_cancel_vote():
     config = dpytest.get_config()
     guild = config.guilds[0]
     await dpytest.message(f"{KoalaBot.COMMAND_PREFIX}vote create Test Vote")
-    dpytest.verify_message(
+    assert dpytest.verify().message().content(
         f"Vote titled `Test Vote` created for guild {guild.name}. Use `{KoalaBot.COMMAND_PREFIX}help vote` to see how to configure it.")
     await dpytest.message(f"{KoalaBot.COMMAND_PREFIX}vote cancel Test Vote")
-    dpytest.verify_message("Vote Test Vote has been cancelled.")
+    assert dpytest.verify().message().content("Vote Test Vote has been cancelled.")
 
 
 def test_option():


### PR DESCRIPTION
Waiting on another version increase (likely 0.5.1) for dpytest.embed_eq() to work again https://github.com/CraftSpider/dpytest/pull/54

In future these are the substitutions used:
`dpytest.verify_message()` & `dpytest.verify_embed()` --> `assert dpytest.verify().message()`
`dpytest.verify_message(assert_nothing=True)` --> `assert dpytest.verify().message().nothing()`
`dpytest.verify_message("message words")` --> `assert dpytest.verify().message().content("message words")`
`dpytest.verify_embed(EMBED)` --> `assert dpytest.verify().message().embed(EMBED)`
`dpytest.verify_activity(ACTIVITY)` --> `assert dpytest.verify().activity().matches(ACTIVITY)`