### PR TITLE
Fix: Changing colours with a # prefixed to the hex value now works

### DIFF
--- a/cogs/ColourRole.py
+++ b/cogs/ColourRole.py
@@ -96,9 +96,14 @@ class ColourRole(commands.Cog):
         :param colour_str: Hex string of colour
         :return: Colour from colour_str
         """
-        r = int(colour_str[:2], 16)
-        g = int(colour_str[2:4], 16)
-        b = int(colour_str[-2:], 16)
+        if(colour_str[0] == '#'):
+            r = int(colour_str[1:3], 16)
+            g = int(colour_str[3:5], 16)
+            b = int(colour_str[-2:], 16)
+        else:
+            r = int(colour_str[:2], 16)
+            g = int(colour_str[2:4], 16)
+            b = int(colour_str[-2:], 16)
         return discord.Colour.from_rgb(r, g, b)
 
     @commands.cooldown(1, 15, commands.BucketType.member)
@@ -316,7 +321,7 @@ class ColourRole(commands.Cog):
         :param colour_str: String to check
         :return: True if a valid colour hex string, false otherwise
         """
-        if re.match("^([A-Fa-f0-9]{6})$", colour_str):
+        if re.match("?#^([A-Fa-f0-9]{6})$", colour_str):
             return True
         return False
 


### PR DESCRIPTION
## Summary
<!-- What is this pull request for? If it fixes an issue use `close #issue-number` -->
`close #215` 
## Checklist
<!-- Put an x inside [ ] to check it, like this: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)

<br>

- [ ] Have you tested the changes? ([pytest](https://docs.pytest.org/) & [dpytest](https://dpytest.readthedocs.io/))
- [x] Have you followed [PEP-8](https://www.python.org/dev/peps/pep-0008/) for naming and styling?  
- [x] Has your code been properly documented with RestructuredText docstrings?
- [ ] Have you added your changes to `CHANGELOG.md` under the `[Unreleased]` heading?
- [ ] If your code added new bot commands, have you updated `documentation.json`?

<br>

- [x] All of this code is your own, or follows the author repo's licence.
