### PR TITLE
Fix: Hex values can now be prefixed with a '#'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ A lot of these commands will only be available to administrators
 ## [Unreleased]
 ### Other
 - Testing updated to use builders in dpytest 0.5.0
+### Colour Role
 - Colour strings can now be prefixed with a #
 
 ## [0.4.3] - 14-05-2021

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ A lot of these commands will only be available to administrators
 ## [Unreleased]
 ### Other
 - Testing updated to use builders in dpytest 0.5.0
+- Colour strings can now be prefixed with a #
 
 ## [0.4.3] - 14-05-2021
 ### Announce
@@ -105,13 +106,13 @@ manually if a timer is deleted.
 
 ### React For Role (RFR)
 ##### Added
-- `rfr create` Create a new, blank rfr message. Default title is `React for Role`. Default description is `Roles below!`. 
-- `rfr delete` Delete an existing rfr message. 
+- `rfr create` Create a new, blank rfr message. Default title is `React for Role`. Default description is `Roles below!`.
+- `rfr delete` Delete an existing rfr message.
 - `rfr addRequiredRole` Add a role required to react to/use rfr functionality. If no role is added, anyone can use rfr functionality.
-- `rfr removeRequiredRole` Removes a role from the group of roles someone requires to use rfr functionality 
+- `rfr removeRequiredRole` Removes a role from the group of roles someone requires to use rfr functionality
 
-- `rfr edit addRoles` Add emoji/role combos to an existing rfr message. 
-- `rfr edit removeRoles` Remove emoji/role combos from an existing rfr message. 
+- `rfr edit addRoles` Add emoji/role combos to an existing rfr message.
+- `rfr edit removeRoles` Remove emoji/role combos from an existing rfr message.
 - `rfr edit description` Edit the description of an existing rfr message  
 - `rfr edit title` Edit the title of an existing rfr message.
 
@@ -147,13 +148,13 @@ manually if a timer is deleted.
 ### Verification
 ##### Changed
 - Fix bot erroring on startup if it had left any guilds with verification enabled
-#### Twitch Alert 
+#### Twitch Alert
 ##### Changed
 - Fix use of full URLs in twitch alerts
 - Fix oauth not updating
 
 ## [0.1.4] - 10-10-2020
-#### Twitch Alert 
+#### Twitch Alert
 ##### Changed
 - Fix TwitchAlert loops crashing
 - Fix repeat on_ready

--- a/cogs/ColourRole.py
+++ b/cogs/ColourRole.py
@@ -96,9 +96,14 @@ class ColourRole(commands.Cog):
         :param colour_str: Hex string of colour
         :return: Colour from colour_str
         """
-        r = int(colour_str[:2], 16)
-        g = int(colour_str[2:4], 16)
-        b = int(colour_str[-2:], 16)
+        if colour_str[0] == '#':
+            r = int(colour_str[1:3], 16)
+            g = int(colour_str[3:5], 16)
+            b = int(colour_str[-2:], 16)
+        else:
+            r = int(colour_str[:2], 16)
+            g = int(colour_str[2:4], 16)
+            b = int(colour_str[-2:], 16)
         return discord.Colour.from_rgb(r, g, b)
 
     @commands.cooldown(1, 15, commands.BucketType.member)
@@ -316,7 +321,7 @@ class ColourRole(commands.Cog):
         :param colour_str: String to check
         :return: True if a valid colour hex string, false otherwise
         """
-        if re.match("^([A-Fa-f0-9]{6})$", colour_str):
+        if re.match("^(#?[A-Fa-f0-9]{6})$", colour_str):
             return True
         return False
 

--- a/tests/test_ColourRole.py
+++ b/tests/test_ColourRole.py
@@ -186,7 +186,7 @@ async def test_is_allowed_to_change_colour_true(utils_cog):
 
 
 @pytest.mark.parametrize("hex_str, value",
-                         [("000000", 0), ("111111", 1118481), ("228822", 2263074), ("ff82ae", 16745134)])
+                         [("000000", 0), ("111111", 1118481), ("228822", 2263074), ("ff82ae", 16745134),("#000000", 0), ("#111111", 1118481), ("#228822", 2263074), ("#ff82ae", 16745134)])
 @pytest.mark.asyncio
 async def test_get_colour_from_hex_str(hex_str, value, role_colour_cog):
     colour: discord.Colour = role_colour_cog.get_colour_from_hex_str(hex_str)
@@ -196,14 +196,15 @@ async def test_get_colour_from_hex_str(hex_str, value, role_colour_cog):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("colour_str, expected",
                          [("", False), (".", False), (" ", False), ("223", False), ("a", False), ("ffgeaa", False),
-                          ("FFeehu", False), ("FFee66", True), ("ffeea7", True), ("ABCDEF", True)])
+                          ("FFeehu", False), ("FFee66", True), ("ffeea7", True), ("ABCDEF", True), ("#ABCDEF", True), ("#123456", True), ("#", False), ("#123", False)])
 async def test_is_valid_colour_str(colour_str, expected, role_colour_cog):
     assert role_colour_cog.is_valid_colour_str(colour_str.upper()) == expected
 
 
 @pytest.mark.parametrize("colour1_str, colour2_str, expected",
                          [("ffffff", "ffffff", 0), ("FFFFFF", "ffffff", 0), ("ffffff", "000000", 764.8339663572415),
-                          ("ff74aa", "6900ff", 362.23060571789074), ("223636", "363636", 29.47456530637899)])
+                          ("ff74aa", "6900ff", 362.23060571789074), ("223636", "363636", 29.47456530637899),("#ffffff", "#ffffff", 0), ("#FFFFFF", "#ffffff", 0), ("#ffffff", "000000", 764.8339663572415),
+                           ("#ff74aa", "#6900ff", 362.23060571789074), ("#223636", "#363636", 29.47456530637899)])
 @pytest.mark.asyncio
 async def test_get_rgb_colour_distance(colour1_str, colour2_str, expected, role_colour_cog):
     colour1 = role_colour_cog.get_colour_from_hex_str(colour1_str)


### PR DESCRIPTION
## Summary
<!-- What is this pull request for? If it fixes an issue use `close #issue-number` -->
 `close #215 `
## Checklist
<!-- Put an x inside [ ] to check it, like this: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)

<br>

- [x] Have you tested the changes? ([pytest](https://docs.pytest.org/) & [dpytest](https://dpytest.readthedocs.io/))
- [x] Have you followed [PEP-8](https://www.python.org/dev/peps/pep-0008/) for naming and styling?  
- [x] Has your code been properly documented with RestructuredText docstrings?
- [x] Have you added your changes to `CHANGELOG.md` under the `[Unreleased]` heading?
- [ ] If your code added new bot commands, have you updated `documentation.json`?

<br>

- [x] All of this code is your own, or follows the author repo's licence.
