### PR TITLE
Fixed get_config_from_argv() to not return NoneType

### DIFF
--- a/KoalaBot.py
+++ b/KoalaBot.py
@@ -63,6 +63,8 @@ def get_config_from_argv():
             if config_dir[0] == "/":
                 config_dir = config_dir[1:]
             config_dir = os.getcwd() + config_dir
+    else:
+        config_dir=""
     return config_dir
 
 

--- a/tests/test_KoalaBot.py
+++ b/tests/test_KoalaBot.py
@@ -74,6 +74,11 @@ def test_get_config_from_argv_linux():
 def test_get_config_from_argv_linux_partial():
     assert KoalaBot.get_config_from_argv() == "/config/"
 
+@mock.patch("os.name", "posix")
+@mock.patch("sys.argv", ["KoalaBot.py", "--config", ""])
+def test_get_config_from_argv_linux_empty():
+    assert KoalaBot.get_config_from_argv() == ""
+
 
 @mock.patch("os.name", "nt")
 @mock.patch("sys.argv", ["KoalaBot.py", "--config", "/config/"])


### PR DESCRIPTION
## Summary
Fixes an issue with get_config_from_argv() that causes it to return NoneType on first bot run, preventing to bot from running

## Checklist
<!-- Put an x inside [ ] to check it, like this: [x] -->

- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)

<br>

- [ ] Have you tested the changes? ([pytest](https://docs.pytest.org/) & [dpytest](https://dpytest.readthedocs.io/))
- [ ] Have you followed [PEP-8](https://www.python.org/dev/peps/pep-0008/) for naming and styling?  
- [ ] Has your code been properly documented with RestructuredText docstrings?
- [ ] Have you added your changes to `CHANGELOG.md` under the `[Unreleased]` heading?
- [ ] If your code added new bot commands, have you updated `documentation.json`?

<br>

- [x] All of this code is your own, or follows the author repo's licence.
