### PR TITLE
fix: config reset on import KoalaBot

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,8 @@
 .gitignore
 .github
 .gitattributes
+*.db
+*.log
 README.md
 CHANGELOG.md
 CONTRIBUTING.md

--- a/KoalaBot.py
+++ b/KoalaBot.py
@@ -60,7 +60,7 @@ def get_config_from_argv():
         config_dir = os.getcwd() + config_dir
     elif config_dir is None:
         config_dir = ""
-    return Path(config_dir)
+    return str(Path(config_dir))
 
 
 CONFIG_DIR = get_config_from_argv()

--- a/KoalaBot.py
+++ b/KoalaBot.py
@@ -24,7 +24,7 @@ import os
 import logging
 import sys
 import argparse
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 
 # Libs
 import discord
@@ -60,7 +60,12 @@ def get_config_from_argv():
         config_dir = os.getcwd() + config_dir
     elif config_dir is None:
         config_dir = ""
-    return str(Path(config_dir))
+    if os.name == 'nt':
+        return str(PureWindowsPath(config_dir))
+    elif os.name == 'posix':
+        return str(PurePosixPath(config_dir))
+    else:
+        return str(Path(config_dir))
 
 
 CONFIG_DIR = get_config_from_argv()

--- a/KoalaBot.py
+++ b/KoalaBot.py
@@ -44,6 +44,8 @@ def parse_args(args):
     """
     parser = argparse.ArgumentParser(description='Start the KoalaBot Discord bot')
     parser.add_argument('--config', help="Config & database directory")
+    parser.add_argument('--cov', help="unused")
+    parser.add_argument('--cov-report', help="unused")
     return parser.parse_args(args)
 
 

--- a/KoalaBot.py
+++ b/KoalaBot.py
@@ -24,6 +24,7 @@ import os
 import logging
 import sys
 import argparse
+from pathlib import Path
 
 # Libs
 import discord
@@ -44,9 +45,8 @@ def parse_args(args):
     """
     parser = argparse.ArgumentParser(description='Start the KoalaBot Discord bot')
     parser.add_argument('--config', help="Config & database directory")
-    parser.add_argument('--cov', help="unused")
-    parser.add_argument('--cov-report', help="unused")
-    return parser.parse_args(args)
+    args, unknown = parser.parse_known_args(args)
+    return args
 
 
 def get_config_from_argv():

--- a/KoalaBot.py
+++ b/KoalaBot.py
@@ -60,18 +60,15 @@ def get_config_from_argv():
             config_dir += "/"
 
         if os.name == 'nt' and config_dir[1] != ":":
-            if config_dir[0] == "/":
-                config_dir = config_dir[1:]
+            # if config_dir[0] == "/":
+            #     config_dir = config_dir[1:]
             config_dir = os.getcwd() + config_dir
     else:
-        config_dir=""
+        config_dir = ""
     return config_dir
 
 
-if __name__ == '__main__':
-    CONFIG_DIR = get_config_from_argv()
-else:
-    CONFIG_DIR = ""
+CONFIG_DIR = get_config_from_argv()
 
 logging.basicConfig(filename=CONFIG_DIR+'KoalaBot.log')
 logging.getLogger().addHandler(logging.StreamHandler(sys.stdout))

--- a/KoalaBot.py
+++ b/KoalaBot.py
@@ -56,18 +56,11 @@ def get_config_from_argv():
     :return: Valid config dir
     """
     config_dir = vars(parse_args(sys.argv[1:])).get("config")
-    if config_dir:
-        config_dir = config_dir.replace("\\", "/")
-        if config_dir[-1] != "/":
-            config_dir += "/"
-
-        if os.name == 'nt' and config_dir[1] != ":":
-            if config_dir[0] == "/" and os.getcwd()[-1] == "/":
-                config_dir = config_dir[1:]
-            config_dir = os.getcwd() + config_dir
-    else:
+    if config_dir and os.name == 'nt' and config_dir[1] != ":":
+        config_dir = os.getcwd() + config_dir
+    elif config_dir is None:
         config_dir = ""
-    return config_dir
+    return Path(config_dir)
 
 
 CONFIG_DIR = get_config_from_argv()

--- a/KoalaBot.py
+++ b/KoalaBot.py
@@ -62,8 +62,8 @@ def get_config_from_argv():
             config_dir += "/"
 
         if os.name == 'nt' and config_dir[1] != ":":
-            # if config_dir[0] == "/":
-            #     config_dir = config_dir[1:]
+            if config_dir[0] == "/" and os.getcwd()[-1] == "/":
+                config_dir = config_dir[1:]
             config_dir = os.getcwd() + config_dir
     else:
         config_dir = ""

--- a/tests/test_KoalaBot.py
+++ b/tests/test_KoalaBot.py
@@ -16,6 +16,7 @@ import discord.ext.test as dpytest
 import mock
 import pytest
 from discord.ext import commands
+import pathlib
 
 # Own modules
 import KoalaBot
@@ -58,54 +59,52 @@ def test_parse_args_config():
 
 
 def test_parse_args_invalid():
-    with mock.patch.object(argparse.ArgumentParser, 'exit') as mock1:
-            KoalaBot.parse_args(["--test", "/test/"])
-    mock1.assert_called_once()
+    assert vars(KoalaBot.parse_args(["--test", "/test/"])).get("config") is None
 
 
 @mock.patch("os.name", "posix")
 @mock.patch("sys.argv", ["KoalaBot.py", "--config", "/config/"])
 def test_get_config_from_argv_linux():
-    assert KoalaBot.get_config_from_argv() == "/config/"
+    assert KoalaBot.get_config_from_argv() == "/config"
 
 
 @mock.patch("os.name", "posix")
 @mock.patch("sys.argv", ["KoalaBot.py", "--config", "/config"])
 def test_get_config_from_argv_linux_partial():
-    assert KoalaBot.get_config_from_argv() == "/config/"
+    assert KoalaBot.get_config_from_argv() == "/config"
 
 @mock.patch("os.name", "posix")
 @mock.patch("sys.argv", ["KoalaBot.py", "--config", ""])
 def test_get_config_from_argv_linux_empty():
-    assert KoalaBot.get_config_from_argv() == ""
+    assert KoalaBot.get_config_from_argv() == "."
 
 
 @mock.patch("os.name", "nt")
 @mock.patch("sys.argv", ["KoalaBot.py", "--config", "/config/"])
 @mock.patch("os.getcwd", mock.MagicMock(return_value="C:/"))
 def test_get_config_from_argv_windows_relative():
-    assert KoalaBot.get_config_from_argv() == "C:/config/"
+    assert KoalaBot.get_config_from_argv() == "C:\\config"
 
 
 @mock.patch("os.name", "nt")
 @mock.patch("sys.argv", ["KoalaBot.py", "--config", "/config"])
 @mock.patch("os.getcwd", mock.MagicMock(return_value="C:/"))
 def test_get_config_from_argv_windows_relative_partial():
-    assert KoalaBot.get_config_from_argv() == "C:/config/"
+    assert KoalaBot.get_config_from_argv() == "C:\\config"
 
 
 @mock.patch("os.name", "nt")
 @mock.patch("sys.argv", ["KoalaBot.py", "--config", "\\config\\"])
 @mock.patch("os.getcwd", mock.MagicMock(return_value="C:/"))
 def test_get_config_from_argv_windows_relative_backslash():
-    assert KoalaBot.get_config_from_argv() == "C:/config/"
+    assert KoalaBot.get_config_from_argv() == "C:\\config"
 
 
 @mock.patch("os.name", "nt")
 @mock.patch("sys.argv", ["KoalaBot.py", "--config", "D:/test/config/"])
 @mock.patch("os.getcwd", mock.MagicMock(return_value="C:/"))
 def test_get_config_from_argv_windows_absolute():
-    assert KoalaBot.get_config_from_argv() == "D:/test/config/"
+    assert KoalaBot.get_config_from_argv() == "D:\\test\\config"
 
 
 def test_test_user_is_owner(test_ctx):

--- a/tests/test_KoalaDBManager.py
+++ b/tests/test_KoalaDBManager.py
@@ -40,5 +40,5 @@ def test_format_db_path_linux_absolute_encrypted():
 @mock.patch("utils.KoalaDBManager.ENCRYPTED_DB", True)
 def test_format_db_path_windows():
     db_path = KoalaDBManager.format_db_path("/test_dir/", "test.db")
-    assert db_path == "/test_dir/windows_test.db"
+    assert db_path == "\\test_dir\\windows_test.db"
 

--- a/utils/KoalaDBManager.py
+++ b/utils/KoalaDBManager.py
@@ -9,6 +9,7 @@ Commented using reStructuredText (reST)
 
 # Built-in/Generic Imports
 import os
+from pathlib import PurePath
 
 # Libs
 from dotenv import load_dotenv
@@ -42,9 +43,9 @@ def format_db_path(directory: str, filename: str):
         directory = ""
 
     if os.name == 'nt' or not ENCRYPTED_DB:
-        return directory + "windows_" + filename
+        return str(PurePath(directory, "windows_" + filename))
     else:
-        return directory + filename
+        return str(PurePath(directory, filename))
 
 
 class KoalaDBManager:


### PR DESCRIPTION
## Summary
<!-- What is this pull request for? If it fixes an issue use `close #issue-number` -->
Fixed config issue resetting, allows docker to run again


## Checklist
<!-- Put an x inside [ ] to check it, like this: [x] -->

- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)

<br>

- [x] Have you tested the changes? ([pytest](https://docs.pytest.org/) & [dpytest](https://dpytest.readthedocs.io/))
- [x] Have you followed [PEP-8](https://www.python.org/dev/peps/pep-0008/) for naming and styling?  
- [x] Has your code been properly documented with RestructuredText docstrings?
- [ ] Have you added your changes to `CHANGELOG.md` under the `[Unreleased]` heading?
- [ ] If your code added new bot commands, have you updated `documentation.json`?

<br>

- [x] All of this code is your own, or follows the author repo's licence.
