### PR TITLE
[BaseCog] Add owner only version command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to KoalaBot will be documented in this file. A lot of these 
 administrators
 
 ## [Unreleased]
+### Other
+- Small improvements
 
 ## [0.4.4] - 19-08-2021
 ### ReactForRole

--- a/cogs/BaseCog.py
+++ b/cogs/BaseCog.py
@@ -226,6 +226,14 @@ class BaseCog(commands.Cog, name='KoalaBot'):
 
         await ctx.send(embed=embed)
 
+    @commands.command(name="version")
+    @commands.check(KoalaBot.is_owner)
+    async def version(self, ctx):
+        """
+        Get the version of KoalaBot
+        """
+        await ctx.send(KoalaBot.__version__)
+
 
 def setup(bot: KoalaBot) -> None:
     """

--- a/tests/test_BaseCog.py
+++ b/tests/test_BaseCog.py
@@ -186,6 +186,13 @@ async def test_invalid_unload_cog(base_cog: BaseCog.BaseCog):
 
 
 @pytest.mark.asyncio
+async def test_version(base_cog: BaseCog.BaseCog):
+    await dpytest.message(KoalaBot.COMMAND_PREFIX + "version")
+    assert dpytest.verify().message().content(KoalaBot.__version__)
+
+
+
+@pytest.mark.asyncio
 async def test_setup():
     with mock.patch.object(discord.ext.commands.bot.Bot, 'add_cog') as mock1:
         BaseCog.setup(KoalaBot.client)


### PR DESCRIPTION
## Summary
<!-- What is this pull request for? If it fixes an issue use `close #issue-number` -->

`k!version` will return the version number
only available to bot owner

**MUST BE REVIEWED TONIGHT** (before 3am)

## Checklist
<!-- Put an x inside [ ] to check it, like this: [x] -->

- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)

<br>

- [x] Have you tested the changes? ([pytest](https://docs.pytest.org/) & [dpytest](https://dpytest.readthedocs.io/))
- [x] Have you followed [PEP-8](https://www.python.org/dev/peps/pep-0008/) for naming and styling?  
- [x] Has your code been properly documented with RestructuredText docstrings?
- [x] Have you added your changes to `CHANGELOG.md` under the `[Unreleased]` heading?
- [ ] If your code added new bot commands, have you updated `documentation.json`?

<br>

- [x] All of this code is your own, or follows the author repo's licence.
