### PR TITLE
(draft) feat: add Koala Backend API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,7 +69,7 @@ local_settings.py
 db.sqlite3
 db.sqlite3-journal
 
-# Flask stuff:
+# Quart stuff:
 instance/
 .webassets-cache
 

--- a/koala/cogs/announce/cog.py
+++ b/koala/cogs/announce/cog.py
@@ -17,7 +17,7 @@ from .log import logger
 from .utils import ANNOUNCE_SEPARATION_DAYS, SECONDS_IN_A_DAY, MAX_MESSAGE_LENGTH
 
 # Flask
-from flask import Blueprint
+from quart import Blueprint
 announce_api = Blueprint('announce_api', __name__)
 
 def announce_is_enabled(ctx):

--- a/koala/cogs/announce/cog.py
+++ b/koala/cogs/announce/cog.py
@@ -48,10 +48,6 @@ class Announce(commands.Cog):
         insert_extension("Announce", 0, True, True)
         self.announce_database_manager = AnnounceDBManager()
 
-    @announce_api.route("/announce")
-    def endpoint():
-        return "announce test"
-
     def not_exceeded_limit(self, guild_id):
         """
         Check if enough days have passed for the user to use the announce function

--- a/koala/cogs/announce/cog.py
+++ b/koala/cogs/announce/cog.py
@@ -16,6 +16,9 @@ from .db import AnnounceDBManager
 from .log import logger
 from .utils import ANNOUNCE_SEPARATION_DAYS, SECONDS_IN_A_DAY, MAX_MESSAGE_LENGTH
 
+# Flask
+from flask import Blueprint
+announce_api = Blueprint('announce_api', __name__)
 
 def announce_is_enabled(ctx):
     """
@@ -44,6 +47,10 @@ class Announce(commands.Cog):
         self.roles = {}
         insert_extension("Announce", 0, True, True)
         self.announce_database_manager = AnnounceDBManager()
+
+    @announce_api.route("/announce")
+    def endpoint():
+        return "announce test"
 
     def not_exceeded_limit(self, guild_id):
         """

--- a/koala/cogs/base/cog.py
+++ b/koala/cogs/base/cog.py
@@ -23,6 +23,9 @@ from .log import logger
 
 # Variables
 
+# Flask
+from flask import Blueprint
+base_api = Blueprint('base_api', __name__)
 
 class BaseCog(commands.Cog, name='KoalaBot'):
     """
@@ -38,6 +41,10 @@ class BaseCog(commands.Cog, name='KoalaBot'):
         self._last_member = None
         self.started = False
         self.COGS_DIR = koalabot.COGS_DIR
+
+    @base_api.route("/base")
+    def endpoint():
+        return "base test"
 
     @commands.Cog.listener()
     async def on_ready(self):
@@ -186,3 +193,5 @@ def setup(bot: koalabot) -> None:
     """
     bot.add_cog(BaseCog(bot))
     logger.info("BaseCog is ready.")
+
+

--- a/koala/cogs/base/cog.py
+++ b/koala/cogs/base/cog.py
@@ -23,8 +23,8 @@ from .log import logger
 
 # Variables
 
-# Flask
-from flask import Blueprint
+# Quart
+from quart import Blueprint
 base_api = Blueprint('base_api', __name__)
 
 class BaseCog(commands.Cog, name='KoalaBot'):

--- a/koala/cogs/base/cog.py
+++ b/koala/cogs/base/cog.py
@@ -11,6 +11,7 @@ Commented using reStructuredText (reST)
 
 # Libs
 from discord.ext import commands
+import json
 
 # Own modules
 import koalabot
@@ -41,10 +42,10 @@ class BaseCog(commands.Cog, name='KoalaBot'):
         self._last_member = None
         self.started = False
         self.COGS_DIR = koalabot.COGS_DIR
+        base_api.add_url_rule('/base', view_func=self.endpoint, methods=['GET'])
 
-    @base_api.route("/base")
-    def endpoint():
-        return "base test"
+    def endpoint(self):
+        return json.dumps("base test")
 
     @commands.Cog.listener()
     async def on_ready(self):

--- a/koala/cogs/colour_role/cog.py
+++ b/koala/cogs/colour_role/cog.py
@@ -24,6 +24,9 @@ from .utils import COLOUR_ROLE_NAMING
 
 # Variables
 
+# Flask
+from flask import Blueprint
+colour_role_api = Blueprint('colour_role_api', __name__)
 
 def is_allowed_to_change_colour(ctx: commands.Context):
     """
@@ -72,6 +75,10 @@ class ColourRole(commands.Cog):
         self.bot = bot
         insert_extension("ColourRole", 0, True, True)
         self.cr_database_manager = ColourRoleDBManager()
+
+    @colour_role_api.route("/colour_role")
+    def endpoint():
+        return "colour_role test"
 
     @commands.Cog.listener()
     async def on_guild_role_delete(self, role: discord.Role):

--- a/koala/cogs/colour_role/cog.py
+++ b/koala/cogs/colour_role/cog.py
@@ -15,7 +15,6 @@ from typing import List, Tuple, Any
 import discord
 from discord.ext import commands, tasks
 import asyncio
-import aiohttp
 
 # Own modules
 import koalabot
@@ -81,7 +80,7 @@ class ColourRole(commands.Cog):
 
     def create_role_api(self, guild_id: int, colour_str: str) -> discord.Role:
         asyncio.run_coroutine_threadsafe(self.create_custom_colour_role(discord.Colour.random(), colour_str, guild_id), self.bot.loop).result()
-        return "colour_role"
+        return 200
 
     @commands.Cog.listener()
     async def on_guild_role_delete(self, role: discord.Role):

--- a/koala/cogs/intro_cog/cog.py
+++ b/koala/cogs/intro_cog/cog.py
@@ -27,8 +27,8 @@ from .utils import get_non_bot_members, ask_for_confirmation, wait_for_message, 
 
 # Variables
 
-# Flask
-from flask import Blueprint
+# Quart
+from quart import Blueprint
 intro_cog_api = Blueprint('intro_cog_api', __name__)
 
 

--- a/koala/cogs/intro_cog/cog.py
+++ b/koala/cogs/intro_cog/cog.py
@@ -27,6 +27,10 @@ from .utils import get_non_bot_members, ask_for_confirmation, wait_for_message, 
 
 # Variables
 
+# Flask
+from flask import Blueprint
+intro_cog_api = Blueprint('intro_cog_api', __name__)
+
 
 class IntroCog(commands.Cog, name="KoalaBot"):
     """
@@ -35,6 +39,10 @@ class IntroCog(commands.Cog, name="KoalaBot"):
 
     def __init__(self, bot):
         self.bot = bot
+
+    @intro_cog_api.route("/intro_cog")
+    def endpoint():
+        return "intro_cog test"
 
     @commands.Cog.listener()
     async def on_guild_join(self, guild: discord.Guild):

--- a/koala/cogs/intro_cog/cog.py
+++ b/koala/cogs/intro_cog/cog.py
@@ -40,10 +40,6 @@ class IntroCog(commands.Cog, name="KoalaBot"):
     def __init__(self, bot):
         self.bot = bot
 
-    @intro_cog_api.route("/intro_cog")
-    def endpoint():
-        return "intro_cog test"
-
     @commands.Cog.listener()
     async def on_guild_join(self, guild: discord.Guild):
         """

--- a/koala/cogs/react_for_role/cog.py
+++ b/koala/cogs/react_for_role/cog.py
@@ -26,8 +26,8 @@ from .db import ReactForRoleDBManager
 from .log import logger
 from .utils import CUSTOM_EMOJI_REGEXP, UNICODE_EMOJI_REGEXP
 
-# Flask
-from flask import Blueprint
+# Quart
+from quart import Blueprint
 react_for_role_api = Blueprint('react_for_role_api', __name__)
 
 def rfr_is_enabled(ctx):

--- a/koala/cogs/react_for_role/cog.py
+++ b/koala/cogs/react_for_role/cog.py
@@ -26,6 +26,9 @@ from .db import ReactForRoleDBManager
 from .log import logger
 from .utils import CUSTOM_EMOJI_REGEXP, UNICODE_EMOJI_REGEXP
 
+# Flask
+from flask import Blueprint
+react_for_role_api = Blueprint('react_for_role_api', __name__)
 
 def rfr_is_enabled(ctx):
     """
@@ -51,6 +54,10 @@ class ReactForRole(commands.Cog):
         self.bot = bot
         insert_extension("ReactForRole", 0, True, True)
         self.rfr_database_manager = ReactForRoleDBManager()
+
+    @react_for_role_api.route("/react_for_role")
+    def endpoint():
+        return "react_for_role test"
 
     @commands.check(koalabot.is_guild_channel)
     @commands.check(koalabot.is_admin)

--- a/koala/cogs/react_for_role/cog.py
+++ b/koala/cogs/react_for_role/cog.py
@@ -55,10 +55,6 @@ class ReactForRole(commands.Cog):
         insert_extension("ReactForRole", 0, True, True)
         self.rfr_database_manager = ReactForRoleDBManager()
 
-    @react_for_role_api.route("/react_for_role")
-    def endpoint():
-        return "react_for_role test"
-
     @commands.check(koalabot.is_guild_channel)
     @commands.check(koalabot.is_admin)
     @commands.check(rfr_is_enabled)

--- a/koala/cogs/text_filter/cog.py
+++ b/koala/cogs/text_filter/cog.py
@@ -21,6 +21,11 @@ from .db import TextFilterDBManager
 from .utils import type_exists, build_word_list_embed, build_moderation_channel_embed, \
     create_default_embed, build_moderation_deleted_embed
 
+# Flask
+from flask import Blueprint
+text_filter_api = Blueprint('text_filter_api', __name__)
+
+
 
 def text_filter_is_enabled(ctx):
     """
@@ -47,6 +52,10 @@ class TextFilter(commands.Cog, name="TextFilter"):
         self.bot = bot
         insert_extension("TextFilter", 0, True, True)
         self.tf_database_manager = TextFilterDBManager(bot)
+    
+    @text_filter_api.route("/text_filter")
+    def endpoint():
+        return "text_filter test"
 
     @commands.command(name="filter", aliases=["filter_word"])
     @commands.check(koalabot.is_admin)

--- a/koala/cogs/text_filter/cog.py
+++ b/koala/cogs/text_filter/cog.py
@@ -21,8 +21,8 @@ from .db import TextFilterDBManager
 from .utils import type_exists, build_word_list_embed, build_moderation_channel_embed, \
     create_default_embed, build_moderation_deleted_embed
 
-# Flask
-from flask import Blueprint
+# Quart
+from quart import Blueprint
 text_filter_api = Blueprint('text_filter_api', __name__)
 
 

--- a/koala/cogs/text_filter/db.py
+++ b/koala/cogs/text_filter/db.py
@@ -10,6 +10,7 @@ Created by: Stefan Cooper
 # Libs
 import discord
 from sqlalchemy import select, delete
+import json
 
 # Own modules
 from koala.db import session_manager
@@ -121,7 +122,7 @@ class TextFilterDBManager:
         """
         with session_manager() as session:
             rows = session.execute(select(TextFilter).filter_by(guild_id=guild_id)).scalars()
-            return [(row.filtered_text, row.filter_type, str(int(row.is_regex))) for row in rows]
+            return json.dumps([(row.filtered_text, row.filter_type,str(int(row.is_regex))) for row in rows])
 
     def get_ignore_list_channels(self, guild_id):
         """

--- a/koala/cogs/twitch_alert/cog.py
+++ b/koala/cogs/twitch_alert/cog.py
@@ -30,6 +30,9 @@ from sqlalchemy import select, or_, delete, and_, update, null
 
 # Variables
 
+# Flask
+from flask import Blueprint
+twitch_alert_api = Blueprint('twitch_alert_api', __name__)
 
 def twitch_is_enabled(ctx):
     """
@@ -65,6 +68,10 @@ class TwitchAlert(commands.Cog):
         self.loop_team_thread = None
         self.running = False
         self.stop_loop = False
+    
+    @twitch_alert_api.route("/twitch_alert")
+    def endpoint():
+        return "twitch_alert test"
 
     @commands.check(koalabot.is_guild_channel)
     @commands.check(koalabot.is_admin)

--- a/koala/cogs/twitch_alert/cog.py
+++ b/koala/cogs/twitch_alert/cog.py
@@ -68,10 +68,6 @@ class TwitchAlert(commands.Cog):
         self.loop_team_thread = None
         self.running = False
         self.stop_loop = False
-    
-    @twitch_alert_api.route("/twitch_alert")
-    def endpoint():
-        return "twitch_alert test"
 
     @commands.check(koalabot.is_guild_channel)
     @commands.check(koalabot.is_admin)

--- a/koala/cogs/twitch_alert/cog.py
+++ b/koala/cogs/twitch_alert/cog.py
@@ -30,8 +30,8 @@ from sqlalchemy import select, or_, delete, and_, update, null
 
 # Variables
 
-# Flask
-from flask import Blueprint
+# Quart
+from quart import Blueprint
 twitch_alert_api = Blueprint('twitch_alert_api', __name__)
 
 def twitch_is_enabled(ctx):

--- a/koala/cogs/verification/cog.py
+++ b/koala/cogs/verification/cog.py
@@ -29,8 +29,9 @@ from .models import VerifiedEmails, NonVerifiedEmails, Roles, ToReVerify
 
 # Variables
 
-
-
+# Flask
+from flask import Blueprint
+verification_api = Blueprint('verification_api', __name__)
 
 def verify_is_enabled(ctx):
     """
@@ -53,6 +54,10 @@ class Verification(commands.Cog, name="Verify"):
     def __init__(self, bot):
         self.bot = bot
         insert_extension("Verify", 0, True, True)
+
+    @verification_api.route("/verification")
+    def endpoint():
+        return "verification test"
 
     @staticmethod
     def send_email(email, token):

--- a/koala/cogs/verification/cog.py
+++ b/koala/cogs/verification/cog.py
@@ -55,10 +55,6 @@ class Verification(commands.Cog, name="Verify"):
         self.bot = bot
         insert_extension("Verify", 0, True, True)
 
-    @verification_api.route("/verification")
-    def endpoint():
-        return "verification test"
-
     @staticmethod
     def send_email(email, token):
         """

--- a/koala/cogs/verification/cog.py
+++ b/koala/cogs/verification/cog.py
@@ -29,8 +29,8 @@ from .models import VerifiedEmails, NonVerifiedEmails, Roles, ToReVerify
 
 # Variables
 
-# Flask
-from flask import Blueprint
+# Quart
+from quart import Blueprint
 verification_api = Blueprint('verification_api', __name__)
 
 def verify_is_enabled(ctx):

--- a/koala/cogs/voting/cog.py
+++ b/koala/cogs/voting/cog.py
@@ -27,6 +27,9 @@ from .utils import make_result_embed
 
 # Variables
 
+# Flask
+from flask import Blueprint
+voting_api = Blueprint('voting_api', __name__)
 
 def currently_configuring():
     """
@@ -79,6 +82,10 @@ class Voting(commands.Cog, name="Vote"):
         self.vote_manager = VoteManager()
         self.vote_manager.load_from_db()
         self.running = False
+
+    @voting_api.route("/voting")
+    def endpoint():
+        return "voting test"
 
     @commands.Cog.listener()
     async def on_ready(self):

--- a/koala/cogs/voting/cog.py
+++ b/koala/cogs/voting/cog.py
@@ -27,8 +27,8 @@ from .utils import make_result_embed
 
 # Variables
 
-# Flask
-from flask import Blueprint
+# Quart
+from quart import Blueprint
 voting_api = Blueprint('voting_api', __name__)
 
 def currently_configuring():

--- a/koala/cogs/voting/cog.py
+++ b/koala/cogs/voting/cog.py
@@ -83,10 +83,6 @@ class Voting(commands.Cog, name="Vote"):
         self.vote_manager.load_from_db()
         self.running = False
 
-    @voting_api.route("/voting")
-    def endpoint():
-        return "voting test"
-
     @commands.Cog.listener()
     async def on_ready(self):
         if not self.running:

--- a/koalabot.py
+++ b/koalabot.py
@@ -27,9 +27,10 @@ import discord
 from discord.ext import commands
 from dotenv import load_dotenv
 import importlib
-from flask import Flask
+from quart import Quart
 from threading import Thread
 from functools import partial
+import asyncio
 
 # Own modules
 from koala.db import extension_enabled
@@ -37,8 +38,8 @@ from koala.utils import error_embed
 from koala.log import logger
 from koala.env import BOT_TOKEN, BOT_OWNER
 
-# Flask
-flask_app = Flask(__name__)
+# quart
+quart_app = Quart(__name__)
 
 # Constants
 load_dotenv()
@@ -106,8 +107,7 @@ def load_apis():
         module_name = 'koala.cogs.'+cog+'.cog'
         print(module_name)
         try:
-            # flask_app.register_blueprint(getimportlib.import_module(module_name))
-            flask_app.register_blueprint(getattr(importlib.import_module(module_name), cog + '_api'))
+            quart_app.register_blueprint(getattr(importlib.import_module(module_name), cog + '_api'))
         except commands.errors.ExtensionAlreadyLoaded:
             print("API already loaded")
 
@@ -196,10 +196,10 @@ if __name__ == "__main__":  # pragma: no cover
     load_all_cogs()
     load_apis()
 
-    # Run Flask in seperate thread
-    flask_run = partial(flask_app.run, host="0.0.0.0", port=5000, debug=True, use_reloader=False)
-    flask_thread = Thread(target=flask_run)
-    flask_thread.start()
+    # Run quart in seperate thread
+    quart_run = partial(quart_app.run, host="0.0.0.0", port=5000, debug=True, use_reloader=False)
+    quart_thread = Thread(target=quart_run)
+    quart_thread.start()
 
     # Starts bot using the given BOT_ID
     client.run(BOT_TOKEN)

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,3 +33,4 @@ urllib3==1.26.7
 wcwidth==0.2.5
 websockets==10.2
 yarl==1.7.2
+Flask==2.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,4 +33,4 @@ urllib3==1.26.7
 wcwidth==0.2.5
 websockets==10.2
 yarl==1.7.2
-Flask==2.0.3
+Quart==2.0.3


### PR DESCRIPTION
## Summary
This PR adds some basic infrastructure for a Koala API. The intention for this PR is purely to raise the discussion for how we implement this.

I propose we implement an API using [Quart](https://pgjones.gitlab.io/quart/) - Quart is forked from Flask but allows more async options. I had originally tried implementing via Flask, but ran into many issues when working with Discord.py.

I think the main point of contention and changes that will be required will be reducing and simplifying the usage of `ctx` (Discord Context) as that won't be available to the API. Where possible we should do things like `self.bot.get_guild(guild_id)` where the `guild_id` is a parameter on the methods (which can be passed as `ctx.guild.id`).

I'll add comments on other points which I think might be interesting and would be interested in hearing your opinions on.

<br>

- [x] All of this code is your own, or follows the author repo's licence.

Contributes to: #0 (Pending issue)

Signed-off-by: Stefan Cooper <stefan.cooper27@gmail.com>
