### PR TITLE
refactor: change how cogs are loaded

### DIFF
--- a/koala/cogs/announce/__init__.py
+++ b/koala/cogs/announce/__init__.py
@@ -1,3 +1,3 @@
 from . import utils, db, log, models
-from .cog import Announce
+from .cog import Announce, setup
 from .announce_message import AnnounceMessage

--- a/koala/cogs/base/__init__.py
+++ b/koala/cogs/base/__init__.py
@@ -1,1 +1,1 @@
-from .cog import BaseCog
+from .cog import BaseCog, setup

--- a/koala/cogs/base/cog.py
+++ b/koala/cogs/base/cog.py
@@ -57,8 +57,8 @@ class BaseCog(commands.Cog, name='KoalaBot'):
         self.bot = bot
         self._last_member = None
         self.started = False
-        self.COGS_DIR = koalabot.COGS_DIR
         self.current_activity = None
+        self.COGS_PACKAGE = koalabot.COGS_PACKAGE
 
     @commands.Cog.listener()
     async def on_ready(self):
@@ -184,7 +184,7 @@ class BaseCog(commands.Cog, name='KoalaBot'):
         :param ctx: Context of the command
         :param extension: The name of the cog
         """
-        self.bot.load_extension(self.COGS_DIR.replace("/", ".") + f'.{extension}')
+        self.bot.load_extension("."+extension, package=self.COGS_PACKAGE)
         await ctx.send(f'{extension} Cog Loaded')
 
     @commands.command(name="unloadCog", aliases=["unload_cog"])
@@ -198,7 +198,7 @@ class BaseCog(commands.Cog, name='KoalaBot'):
         if extension == "BaseCog":
             await ctx.send("Sorry, you can't unload the base cog")
         else:
-            self.bot.unload_extension(self.COGS_DIR.replace("/", ".") + f'.{extension}')
+            self.bot.unload_extension("."+extension, package=self.COGS_PACKAGE)
             await ctx.send(f'{extension} Cog Unloaded')
 
     @commands.command(name="enableExt", aliases=["enable_koala_ext"])

--- a/koala/cogs/colour_role/__init__.py
+++ b/koala/cogs/colour_role/__init__.py
@@ -1,2 +1,2 @@
 from . import utils, db, log, models
-from .cog import ColourRole
+from .cog import ColourRole, setup

--- a/koala/cogs/intro_cog/__init__.py
+++ b/koala/cogs/intro_cog/__init__.py
@@ -1,2 +1,2 @@
 from . import utils, db, models
-from .cog import IntroCog
+from .cog import IntroCog, setup

--- a/koala/cogs/react_for_role/__init__.py
+++ b/koala/cogs/react_for_role/__init__.py
@@ -1,2 +1,2 @@
 from . import utils, db, models
-from .cog import ReactForRole
+from .cog import ReactForRole, setup

--- a/koala/cogs/text_filter/__init__.py
+++ b/koala/cogs/text_filter/__init__.py
@@ -1,2 +1,2 @@
 from . import utils, db, models
-from .cog import TextFilter
+from .cog import TextFilter, setup

--- a/koala/cogs/twitch_alert/__init__.py
+++ b/koala/cogs/twitch_alert/__init__.py
@@ -1,2 +1,2 @@
 from . import utils, db, twitch_handler, log, models
-from .cog import TwitchAlert
+from .cog import TwitchAlert, setup

--- a/koala/cogs/verification/__init__.py
+++ b/koala/cogs/verification/__init__.py
@@ -1,2 +1,2 @@
 from . import db, log, models
-from .cog import Verification
+from .cog import Verification, setup

--- a/koala/cogs/voting/__init__.py
+++ b/koala/cogs/voting/__init__.py
@@ -1,2 +1,2 @@
 from . import utils, db, log, models
-from .cog import Voting
+from .cog import Voting, setup

--- a/koalabot.py
+++ b/koalabot.py
@@ -40,7 +40,7 @@ load_dotenv()
 COMMAND_PREFIX = "k!"
 OPT_COMMAND_PREFIX = "K!"
 STREAMING_URL = "https://twitch.tv/thenuel"
-COGS_DIR = "koala/cogs"
+COGS_DIR = os.environ.get("COGS_DIR") or "koala/cogs"
 TEST_USER = "TestUser#0001"  # Test user for dpytest
 TEST_BOT_USER = "FakeApp#0001"  # Test bot user for dpytest
 KOALA_GREEN = discord.Colour.from_rgb(0, 170, 110)

--- a/koalabot.py
+++ b/koalabot.py
@@ -40,7 +40,7 @@ load_dotenv()
 COMMAND_PREFIX = "k!"
 OPT_COMMAND_PREFIX = "K!"
 STREAMING_URL = "https://twitch.tv/thenuel"
-COGS_DIR = os.environ.get("COGS_DIR") or "koala/cogs"
+COGS_PACKAGE = "koala.cogs"
 TEST_USER = "TestUser#0001"  # Test user for dpytest
 TEST_BOT_USER = "FakeApp#0001"  # Test bot user for dpytest
 KOALA_GREEN = discord.Colour.from_rgb(0, 170, 110)
@@ -102,9 +102,9 @@ def load_all_cogs():
 
     for cog in ENABLED_COGS:
         try:
-            bot.load_extension("."+cog, package='koala.cogs')
+            bot.load_extension("."+cog, package=COGS_PACKAGE)
         except commands.errors.ExtensionAlreadyLoaded:
-            bot.reload_extension("."+cog, package='koala.cogs')
+            bot.reload_extension("."+cog, package=COGS_PACKAGE)
 
     logger.info("All cogs loaded")
 

--- a/koalabot.py
+++ b/koalabot.py
@@ -97,24 +97,14 @@ def is_guild_channel(ctx):
 
 def load_all_cogs():
     """
-    Loads all cogs in COGS_DIR into the client
+    Loads all cogs in ENABLED_COGS into the client
     """
-    UNRELEASED = []
 
-    for filename in os.listdir(COGS_DIR):
-        if filename.endswith('.py') and filename not in UNRELEASED and filename != "__init__.py":
-            try:
-                bot.load_extension(COGS_DIR.replace("/", ".") + f'.{filename[:-3]}')
-            except commands.errors.ExtensionAlreadyLoaded:
-                bot.reload_extension(COGS_DIR.replace("/", ".") + f'.{filename[:-3]}')
-
-    # New Approach
     for cog in ENABLED_COGS:
-        module_name = 'koala.cogs.'+cog+'.cog'
         try:
-            bot.load_extension(module_name)
+            bot.load_extension("."+cog, package='koala.cogs')
         except commands.errors.ExtensionAlreadyLoaded:
-            bot.reload_extension(module_name)
+            bot.reload_extension("."+cog, package='koala.cogs')
 
     logger.info("All cogs loaded")
 

--- a/tests/cogs/base/test_cog.py
+++ b/tests/cogs/base/test_cog.py
@@ -191,8 +191,8 @@ async def test_invalid_clear(base_cog: BaseCog):
 @pytest.mark.asyncio
 async def test_load_cog(base_cog: BaseCog):
     with mock.patch.object(discord.ext.commands.bot.Bot, 'load_extension') as mock1:
-        await dpytest.message(koalabot.COMMAND_PREFIX + "load_cog BaseCog")
-    mock1.assert_called_with(".BaseCog", package="koala.cogs")
+        await dpytest.message(koalabot.COMMAND_PREFIX + "load_cog base")
+    mock1.assert_called_with(".base", package="koala.cogs")
 
 
 @pytest.mark.asyncio

--- a/tests/cogs/base/test_cog.py
+++ b/tests/cogs/base/test_cog.py
@@ -54,7 +54,7 @@ async def base_cog(bot: commands.Bot):
     return base_cog
 
 
-@mock.patch("koalabot.COGS_DIR", "tests/tests_utils/fake_load_all_cogs")
+@mock.patch("koalabot.COGS_PACKAGE", "tests.tests_utils.fake_load_all_cogs")
 @mock.patch("koalabot.ENABLED_COGS", [])
 @pytest.mark.asyncio
 async def test_list_koala_ext_disabled(base_cog):
@@ -68,8 +68,8 @@ async def test_list_koala_ext_disabled(base_cog):
     assert dpytest.verify().message().embed(embed=expected_embed)
 
 
-@mock.patch("koalabot.COGS_DIR", "tests/tests_utils/fake_load_all_cogs")
-@mock.patch("koalabot.ENABLED_COGS", [])
+@mock.patch("koalabot.COGS_PACKAGE", "tests.tests_utils.fake_load_all_cogs")
+@mock.patch("koalabot.ENABLED_COGS", ['greetings_cog'])
 @pytest.mark.asyncio
 async def test_enable_koala_ext(base_cog):
     koalabot.load_all_cogs()
@@ -82,8 +82,8 @@ async def test_enable_koala_ext(base_cog):
     assert dpytest.verify().message().embed(embed=expected_embed)
 
 
-@mock.patch("koalabot.COGS_DIR", "tests/tests_utils/fake_load_all_cogs")
-@mock.patch("koalabot.ENABLED_COGS", [])
+@mock.patch("koalabot.COGS_PACKAGE", "tests.tests_utils.fake_load_all_cogs")
+@mock.patch("koalabot.ENABLED_COGS", ['greetings_cog'])
 @pytest.mark.asyncio
 async def test_disable_koala_ext(base_cog):
     await test_enable_koala_ext(base_cog)
@@ -192,7 +192,7 @@ async def test_invalid_clear(base_cog: BaseCog):
 async def test_load_cog(base_cog: BaseCog):
     with mock.patch.object(discord.ext.commands.bot.Bot, 'load_extension') as mock1:
         await dpytest.message(koalabot.COMMAND_PREFIX + "load_cog BaseCog")
-    mock1.assert_called_with('koala.cogs.BaseCog')
+    mock1.assert_called_with(".BaseCog", package="koala.cogs")
 
 
 @pytest.mark.asyncio
@@ -211,22 +211,22 @@ async def test_unload_base_cog(base_cog: BaseCog):
 
 @pytest.mark.asyncio
 async def test_load_valid_cog(base_cog: BaseCog):
-    base_cog.COGS_DIR = "tests/tests_utils/fake_load_all_cogs"
+    base_cog.COGS_PACKAGE = "tests.tests_utils.fake_load_all_cogs"
     with mock.patch.object(discord.ext.commands.bot.Bot, 'load_extension') as mock1:
         await dpytest.message(koalabot.COMMAND_PREFIX + "load_cog Greetings")
-    mock1.assert_called_with("tests.tests_utils.fake_load_all_cogs.Greetings")
+    mock1.assert_called_with(".Greetings", package="tests.tests_utils.fake_load_all_cogs")
 
 
 @pytest.mark.asyncio
 async def test_load_and_unload_valid_cog(base_cog: BaseCog):
-    base_cog.COGS_DIR = "tests/tests_utils/fake_load_all_cogs"
+    base_cog.COGS_PACKAGE = "tests.tests_utils.fake_load_all_cogs"
     with mock.patch.object(discord.ext.commands.bot.Bot, 'load_extension') as mock1:
         await dpytest.message(koalabot.COMMAND_PREFIX + "load_cog Greetings")
-    mock1.assert_called_with("tests.tests_utils.fake_load_all_cogs.Greetings")
+    mock1.assert_called_with(".Greetings", package="tests.tests_utils.fake_load_all_cogs")
 
     with mock.patch.object(discord.ext.commands.bot.Bot, 'unload_extension') as mock1:
         await dpytest.message(koalabot.COMMAND_PREFIX + "unload_cog Greetings")
-    mock1.assert_called_with('tests.tests_utils.fake_load_all_cogs.Greetings')
+    mock1.assert_called_with(".Greetings", package="tests.tests_utils.fake_load_all_cogs")
 
 
 @pytest.mark.asyncio

--- a/tests/test_koalabot.py
+++ b/tests/test_koalabot.py
@@ -95,12 +95,12 @@ def test_not_admin_is_admin(test_ctx):
     koalabot.is_dpytest = True
 
 
-@mock.patch("koalabot.COGS_DIR", "tests/tests_utils/fake_load_all_cogs")
-@mock.patch("koalabot.ENABLED_COGS", [])
+@mock.patch("koalabot.COGS_PACKAGE", "tests.tests_utils.fake_load_all_cogs")
+@mock.patch("koalabot.ENABLED_COGS", ['greetings_cog'])
 def test_load_all_cogs():
     with mock.patch.object(discord.ext.commands.bot.Bot, 'load_extension') as mock1:
         koalabot.load_all_cogs()
-    mock1.assert_called_with("tests.tests_utils.fake_load_all_cogs.greetings_cog")
+    mock1.assert_called_with(".greetings_cog", package="tests.tests_utils.fake_load_all_cogs")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Signed-off-by: Stefan Cooper <stefan.cooper27@gmail.com>

## Summary
<!-- What is this pull request for? If it fixes an issue use `close #issue-number` -->
This change allows the frontend to simply change an env var in our submodule and run the Python bot alongside the frontend application. This will be important to be able to run the backend API alongside the frontend.

## Checklist
<!-- Put an x inside [ ] to check it, like this: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)

<br>

- [x] Have you tested the changes? ([pytest](https://docs.pytest.org/) & [dpytest](https://dpytest.readthedocs.io/))
- [x] Have you followed [PEP-8](https://www.python.org/dev/peps/pep-0008/) for naming and styling?  
- [x] Has your code been properly documented with RestructuredText docstrings?
- [ ] Have you added your changes to `CHANGELOG.md` under the `[Unreleased]` heading?
- [ ] If your code added new bot commands, have you updated `documentation.json`?

<br>

- [x] All of this code is your own, or follows the author repo's licence.
