### PR TITLE
fix: base cog api now works

### DIFF
--- a/koala/cogs/base/api.py
+++ b/koala/cogs/base/api.py
@@ -130,15 +130,14 @@ class BaseEndpoint:
         return core.get_version()
 
     @parse_request
-    async def post_load_cog(self, extension, package):
+    async def post_load_cog(self, extension):
         """
         Loads a cog from the cogs folder
         :param extension: name of the cog
-        :param package: package of the cogs
         :return:
         """
         try:
-            await core.load_cog(self._bot, extension, package)
+            await core.load_cog(self._bot, extension)
         except BaseException as e:
             error = 'Error loading cog: {}'.format(handleActivityError(e))
             logger.error(error)
@@ -147,15 +146,14 @@ class BaseEndpoint:
         return {'message': 'Cog loaded'}
 
     @parse_request
-    async def post_unload_cog(self, extension, package):
+    async def post_unload_cog(self, extension):
         """
         Unloads a cog from the cogs folder
         :param extension: name of the cog
-        :param package: package of the cogs
         :return:
         """
         try:
-            await core.unload_cog(self._bot, extension, package)
+            await core.unload_cog(self._bot, extension)
         except BaseException as e:
             error = 'Error unloading cog: {}'.format(handleActivityError(e))
             logger.error(error)

--- a/koala/cogs/base/cog.py
+++ b/koala/cogs/base/cog.py
@@ -188,7 +188,7 @@ class BaseCog(commands.Cog, name='KoalaBot'):
         :param ctx: Context of the command
         :param extension: The name of the cog
         """
-        await ctx.send(await core.load_cog(self.bot, extension, koalabot.COGS_PACKAGE))
+        await ctx.send(await core.load_cog(self.bot, extension))
 
     @commands.command(name="unloadCog", aliases=["unload_cog"])
     @commands.check(koalabot.is_owner)
@@ -198,7 +198,7 @@ class BaseCog(commands.Cog, name='KoalaBot'):
         :param ctx: Context of the command
         :param extension: The name of the cog
         """
-        await ctx.send(await core.unload_cog(self.bot, extension, koalabot.COGS_PACKAGE))
+        await ctx.send(await core.unload_cog(self.bot, extension))
 
     @commands.command(name="enableExt", aliases=["enable_koala_ext"])
     @commands.check(koalabot.is_admin)

--- a/koala/cogs/base/core.py
+++ b/koala/cogs/base/core.py
@@ -127,18 +127,18 @@ async def purge(bot: Bot, channel_id, amount):
     return await channel.purge(limit=amount+1)
 
 
-async def load_cog(bot: Bot, extension, package):
+async def load_cog(bot: Bot, extension):
     """
     Loads a cog from the cogs folder
     :param extension:
     :param package:
     :return:
     """
-    await bot.load_extension("."+extension, package=package)
+    await bot.load_extension("."+extension, package=koalabot.COGS_PACKAGE)
     return f'{extension} Cog Loaded'
 
 
-async def unload_cog(bot: Bot, extension, package):
+async def unload_cog(bot: Bot, extension):
     """
     Unloads a cog from the cogs folder
     :param extension:
@@ -148,7 +148,7 @@ async def unload_cog(bot: Bot, extension, package):
     if extension == "base" or extension == "BaseCog":
         raise discord.ext.commands.errors.ExtensionError(message=f"Sorry, you can't unload the base cog", name=extension)
     else:
-        await bot.unload_extension("."+extension, package=package)
+        await bot.unload_extension("."+extension, package=koalabot.COGS_PACKAGE)
         return f'{extension} Cog Unloaded'
 
 

--- a/koala/rest/api.py
+++ b/koala/rest/api.py
@@ -40,8 +40,13 @@ def build_response(status_code, data):
     :param data:
     :return:
     """
+    if data is not None:
+        body = json.dumps(data, cls=EnhancedJSONEncoder)
+    else:
+        body = None
+
     return aiohttp.web.Response(status=status_code,
-                    body=json.dumps(data, cls=EnhancedJSONEncoder),
+                    body=body,
                     content_type='application/json')
 
 
@@ -92,7 +97,7 @@ def parse_request(*args, **kwargs):
             available_args = {}
 
             if (request.method == "POST" or request.method == "PUT") and request.has_body:
-                body = await request.post()
+                body = await request.json()
                 for arg in wanted_args:
                     if arg in body:
                         available_args[arg] = body[arg]

--- a/tests/cogs/base/test_api.py
+++ b/tests/cogs/base/test_api.py
@@ -53,7 +53,7 @@ PUT /scheduled-activity
 '''
 
 async def test_put_schedule_activity(api_client):
-    resp = await api_client.put('/scheduled-activity', data=(
+    resp = await api_client.put('/scheduled-activity', json=(
         {
             'activity_type': 'playing',
             'message': 'test',
@@ -67,7 +67,7 @@ async def test_put_schedule_activity(api_client):
 
 
 async def test_put_schedule_activity_missing_param(api_client):
-    resp = await api_client.put('/scheduled-activity', data=(
+    resp = await api_client.put('/scheduled-activity', json=(
         {
             'activity_type': 'playing',
             'message': 'test',
@@ -80,7 +80,7 @@ async def test_put_schedule_activity_missing_param(api_client):
 
 
 async def test_put_schedule_activity_bad_activity(api_client):
-    resp = await api_client.put('/scheduled-activity', data=(
+    resp = await api_client.put('/scheduled-activity', json=(
         {
             'activity_type': 'invalidActivity',
             'message': 'test',
@@ -93,7 +93,7 @@ async def test_put_schedule_activity_bad_activity(api_client):
 
 
 async def test_put_schedule_activity_bad_start_time(api_client):
-    resp = await api_client.put('/scheduled-activity', data=(
+    resp = await api_client.put('/scheduled-activity', json=(
         {
             'activity_type': 'playing',
             'message': 'test',
@@ -106,7 +106,7 @@ async def test_put_schedule_activity_bad_start_time(api_client):
 
 
 async def test_put_schedule_activity_bad_end_time(api_client):
-    resp = await api_client.put('/scheduled-activity', data=(
+    resp = await api_client.put('/scheduled-activity', json=(
         {
             'activity_type': 'invalidActivity',
             'message': 'test',
@@ -125,7 +125,7 @@ PUT /activity
 
 
 async def test_put_set_activity(api_client):
-    resp = await api_client.put('/activity', data=(
+    resp = await api_client.put('/activity', json=(
         {
             'activity_type': 'playing',
             'name': 'test',
@@ -138,7 +138,7 @@ async def test_put_set_activity(api_client):
 
 
 async def test_put_set_activity_bad_req(api_client):
-    resp = await api_client.put('/activity', data=(
+    resp = await api_client.put('/activity', json=(
         {
             'activity_type': 'invalidActivity',
             'name': 'test',
@@ -149,7 +149,7 @@ async def test_put_set_activity_bad_req(api_client):
 
 
 async def test_put_set_activity_missing_param(api_client):
-    resp = await api_client.put('/activity', data=(
+    resp = await api_client.put('/activity', json=(
         {
             'activity_type': 'invalidActivity',
             'url': 'test.com'
@@ -203,53 +203,53 @@ POST /load-cog
 '''
 
 async def test_post_load_cog(api_client):
-    resp = await api_client.post('/load-cog', data=(
+    resp = await api_client.post('/load-cog', json=(
         {
             'extension': 'announce',
-            'package': koalabot.COGS_PACKAGE
+            # 'package': koalabot.COGS_PACKAGE
         }))
     assert resp.status == OK
     text = await resp.text()
     assert text == '{"message": "Cog loaded"}'
 
 async def test_post_load_base_cog(api_client):
-    resp = await api_client.post('/load-cog', data=(
+    resp = await api_client.post('/load-cog', json=(
         {
             'extension': 'base',
-            'package': koalabot.COGS_PACKAGE
+            # 'package': koalabot.COGS_PACKAGE
         }))
     assert resp.status == OK
     text = await resp.text()
     assert text == '{"message": "Cog loaded"}'
 
 async def test_post_load_cog_bad_req(api_client):
-    resp = await api_client.post('/load-cog', data=(
+    resp = await api_client.post('/load-cog', json=(
         {
             'extension': 'invalidCog',
-            'package': koalabot.COGS_PACKAGE
+            # 'package': koalabot.COGS_PACKAGE
         }))
     assert resp.status == UNPROCESSABLE_ENTITY
     assert await resp.text() == '422: Error loading cog: Invalid extension'
 
-async def test_post_load_cog_missing_param(api_client):
-    resp = await api_client.post('/load-cog', data=(
-        {
-            'extension': 'invalidCog'
-        }))
-    assert resp.status == BAD_REQUEST
-    assert await resp.text() == "400: Unsatisfied Arguments: {'package'}"
+# async def test_post_load_cog_missing_param(api_client):
+#     resp = await api_client.post('/load-cog', json=(
+#         {
+#             'extension': 'invalidCog'
+#         }))
+#     assert resp.status == BAD_REQUEST
+#     assert await resp.text() == "400: Unsatisfied Arguments: {'package'}"
 
 async def test_post_load_cog_already_loaded(api_client):
-    await api_client.post('/load-cog', data=(
+    await api_client.post('/load-cog', json=(
         {
             'extension': 'announce',
-            'package': koalabot.COGS_PACKAGE
+            # 'package': koalabot.COGS_PACKAGE
         }))
     
-    resp = await api_client.post('/load-cog', data=(
+    resp = await api_client.post('/load-cog', json=(
         {
             'extension': 'announce',
-            'package': koalabot.COGS_PACKAGE
+            # 'package': koalabot.COGS_PACKAGE
         }))
     assert resp.status == UNPROCESSABLE_ENTITY
     assert await resp.text() == '422: Error loading cog: Already loaded'
@@ -261,43 +261,43 @@ POST /unload-cog
 '''
 
 async def test_post_unload_cog(api_client):
-    await api_client.post('/load-cog', data=(
+    await api_client.post('/load-cog', json=(
         {
             'extension': 'announce',
-            'package': koalabot.COGS_PACKAGE
+            # 'package': koalabot.COGS_PACKAGE
         }))
 
-    resp = await api_client.post('/unload-cog', data=(
+    resp = await api_client.post('/unload-cog', json=(
         {
             'extension': 'announce',
-            'package': koalabot.COGS_PACKAGE
+            # 'package': koalabot.COGS_PACKAGE
         }))
     assert resp.status == OK
     text = await resp.text()
     assert text == '{"message": "Cog unloaded"}'
 
 async def test_post_unload_cog_not_loaded(api_client):
-    resp = await api_client.post('/unload-cog', data=(
+    resp = await api_client.post('/unload-cog', json=(
         {
             'extension': 'announce',
-            'package': koalabot.COGS_PACKAGE
+            # 'package': koalabot.COGS_PACKAGE
         }))
     assert resp.status == UNPROCESSABLE_ENTITY
     assert await resp.text() == '422: Error unloading cog: Extension not loaded'
 
-async def test_post_unload_cog_missing_param(api_client):
-    resp = await api_client.post('/unload-cog', data=(
-        {
-            'extension': 'invalidCog'
-        }))
-    assert resp.status == BAD_REQUEST
-    assert await resp.text() == "400: Unsatisfied Arguments: {'package'}"
+# async def test_post_unload_cog_missing_param(api_client):
+#     resp = await api_client.post('/unload-cog', json=(
+#         {
+#             'extension': 'invalidCog'
+#         }))
+#     assert resp.status == BAD_REQUEST
+#     assert await resp.text() == "400: Unsatisfied Arguments: {'package'}"
 
 async def test_post_unload_base_cog(api_client):
-    resp = await api_client.post('/unload-cog', data=(
+    resp = await api_client.post('/unload-cog', json=(
         {
             'extension': 'BaseCog',
-            'package': koalabot.COGS_PACKAGE
+            # 'package': koalabot.COGS_PACKAGE
         }))
     assert resp.status == UNPROCESSABLE_ENTITY
     text = await resp.text()
@@ -313,7 +313,7 @@ POST /enable-extension
 async def test_post_enable_extension(api_client, bot):
     await koalabot.load_all_cogs(bot)
     guild: discord.Guild = dpytest.get_config().guilds[0]
-    resp = await api_client.post('/enable-extension', data=({
+    resp = await api_client.post('/enable-extension', json=({
         'guild_id': guild.id,
         'koala_ext': 'Announce'
     }))
@@ -325,7 +325,7 @@ async def test_post_enable_extension(api_client, bot):
 async def test_post_enable_extension_bad_req(api_client):
     guild: discord.Guild = dpytest.get_config().guilds[0]
 
-    resp = await api_client.post('/enable-extension', data=(
+    resp = await api_client.post('/enable-extension', json=(
         {
             'guild_id': guild.id,
             'koala_ext': 'Invalid Extension'
@@ -336,7 +336,7 @@ async def test_post_enable_extension_bad_req(api_client):
 
 async def test_post_enable_extension_missing_param(api_client):
     guild: discord.Guild = dpytest.get_config().guilds[0]
-    resp = await api_client.post('/enable-extension', data=(
+    resp = await api_client.post('/enable-extension', json=(
         {
             'guild_id': guild.id
         }))
@@ -354,13 +354,13 @@ POST /disable-extension
 async def test_post_disable_extension(api_client, bot):
     await koalabot.load_all_cogs(bot)
     guild: discord.Guild = dpytest.get_config().guilds[0]
-    setup = await api_client.post('/enable-extension', data=({
+    setup = await api_client.post('/enable-extension', json=({
         'guild_id': guild.id,
         'koala_ext': 'Announce'
     }))
     assert setup.status == OK
 
-    resp = await api_client.post('/disable-extension', data=({
+    resp = await api_client.post('/disable-extension', json=({
         'guild_id': guild.id,
         'koala_ext': 'Announce'
     }))
@@ -370,7 +370,7 @@ async def test_post_disable_extension(api_client, bot):
 
 async def test_post_disable_extension_not_enabled(api_client):
     guild: discord.Guild = dpytest.get_config().guilds[0]
-    resp = await api_client.post('/disable-extension', data=({
+    resp = await api_client.post('/disable-extension', json=({
         'guild_id': guild.id,
         'koala_ext': 'Announce'
     }))
@@ -380,7 +380,7 @@ async def test_post_disable_extension_not_enabled(api_client):
 
 async def test_post_disable_extension_missing_param(api_client):
     guild: discord.Guild = dpytest.get_config().guilds[0]
-    resp = await api_client.post('/disable-extension', data=({
+    resp = await api_client.post('/disable-extension', json=({
         'guild_id': guild.id
     }))
     assert resp.status == BAD_REQUEST
@@ -390,7 +390,7 @@ async def test_post_disable_extension_missing_param(api_client):
 async def test_post_disable_extension_bad_req(api_client):
     guild: discord.Guild = dpytest.get_config().guilds[0]
 
-    resp = await api_client.post('/disable-extension', data=(
+    resp = await api_client.post('/disable-extension', json=(
         {
             'guild_id': guild.id,
             'koala_ext': 'Invalid Extension'

--- a/tests/cogs/base/test_core.py
+++ b/tests/cogs/base/test_core.py
@@ -86,54 +86,54 @@ async def test_purge(bot: commands.Bot):
 @mock.patch("koalabot.ENABLED_COGS", ['announce'])
 @pytest.mark.asyncio
 async def test_load_cog(bot: commands.Bot):
-    resp = await core.load_cog(bot, "announce", "koala.cogs")
+    resp = await core.load_cog(bot, "announce")
     assert resp == "announce Cog Loaded"
 
 
 @pytest.mark.asyncio
 async def test_load_base_cog(bot: commands.Bot):
-    resp = await core.load_cog(bot, "base", "koala.cogs")
+    resp = await core.load_cog(bot, "base")
     assert resp == "base Cog Loaded"
 
 
 @pytest.mark.asyncio
 async def test_load_invalid_cog(bot: commands.Bot):
     with pytest.raises(discord.ext.commands.errors.ExtensionNotFound, match="Extension 'koala.cogs.FakeCog' could not be loaded."):
-        await core.load_cog(bot, "FakeCog", "koala.cogs")
+        await core.load_cog(bot, "FakeCog")
 
 
 @mock.patch("koalabot.ENABLED_COGS", ['announce'])
 @pytest.mark.asyncio
 async def test_load_already_loaded_cog(bot: commands.Bot):
-    await core.load_cog(bot, "announce", "koala.cogs")
+    await core.load_cog(bot, "announce")
     with pytest.raises(discord.ext.commands.errors.ExtensionAlreadyLoaded, match="Extension 'koala.cogs.announce' is already loaded"):
-        await core.load_cog(bot, "announce", "koala.cogs")
+        await core.load_cog(bot, "announce")
 
 # Unload cogs
 
 @pytest.mark.asyncio
 async def test_unload_cog(bot: commands.Bot):
-    await core.load_cog(bot, "announce", "koala.cogs")
-    resp = await core.unload_cog(bot, "announce", "koala.cogs")
+    await core.load_cog(bot, "announce")
+    resp = await core.unload_cog(bot, "announce")
     assert resp == "announce Cog Unloaded"
 
 
 @pytest.mark.asyncio
 async def test_unload_base_cog(bot: commands.Bot):
     with pytest.raises(discord.ext.commands.errors.ExtensionError, match="Sorry, you can't unload the base cog"):
-        await core.unload_cog(bot, "base", "koala.cogs")
+        await core.unload_cog(bot, "base")
 
 
 @pytest.mark.asyncio
 async def test_unload_not_loaded_cog(bot: commands.Bot):
     with pytest.raises(discord.ext.commands.errors.ExtensionNotLoaded, match="Extension 'koala.cogs.announce' has not been loaded."):
-        await core.unload_cog(bot, "announce", "koala.cogs")
+        await core.unload_cog(bot, "announce")
 
 
 @pytest.mark.asyncio
 async def test_unload_invalid_cog(bot: commands.Bot):
     with pytest.raises(discord.ext.commands.errors.ExtensionNotLoaded, match="Extension 'koala.cogs.FakeCog' has not been loaded."):
-        await core.unload_cog(bot, "FakeCog", "koala.cogs")
+        await core.unload_cog(bot, "FakeCog")
 
 # Enable extensions
 


### PR DESCRIPTION
## Summary
Closes #388 

Incorporated Jack's code for making JSON posts work
Removed `package` parameter requirement for loading and unloading cogs (this was requested a while ago).

## Checklist
<!-- Put an x inside [ ] to check it, like this: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)

<br>

- [x] Have you tested the changes? ([pytest](https://docs.pytest.org/) & [dpytest](https://dpytest.readthedocs.io/))
- [ ] Have you followed [PEP-8](https://www.python.org/dev/peps/pep-0008/) for naming and styling?  
- [ ] Has your code been properly documented with RestructuredText docstrings?
- [ ] Have you added your changes to `CHANGELOG.md` under the `[Unreleased]` heading?
- [ ] If your code added new bot commands, have you updated `documentation.json`?

<br>

- [x] All of this code is your own, or follows the author repo's licence.
