### PR TITLE
Fix injection vulnerability with multiple emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ administrators
 - made email verification case insensitive
 - Added optimisations for verified roles
 - Add backend API
+- Fix an issue where multiple emails can be passed to bypass domain-specific verification
 
 ## [0.6.0] - 01-01-2023
 - Upgraded to discord.py 2.1.0

--- a/koala/cogs/verification/core.py
+++ b/koala/cogs/verification/core.py
@@ -167,7 +167,7 @@ async def email_verify_send(user_id, email, bot, force=False, *, session: Sessio
     if valid_emails:
         email = valid_emails[0]
     else:
-        raise errors.VerifyExistsException("No Valid Emails found") # Wrong Exception, suggest alternate?
+        raise errors.VerifyException("No Valid Emails found")
     
     
     already_verified = session.execute(select(VerifiedEmails).filter_by(email=email)).scalar()

--- a/koala/cogs/verification/core.py
+++ b/koala/cogs/verification/core.py
@@ -2,6 +2,7 @@
 import random
 import string
 from typing import List, Dict
+import re
 
 # Futures
 # Built-in/Generic Imports
@@ -159,6 +160,16 @@ async def remove_blacklist_member(user_id, guild_id, role_id, suffix, bot: Bot, 
 @assign_session
 async def email_verify_send(user_id, email, bot, force=False, *, session: Session):
     email = email.lower()
+    
+    # Take only the first email, preventing injection / verification bypass with ',' , ';' , ':', etc.
+    email_regex = r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b'
+    valid_emails = re.findall(email_regex, email)
+    if valid_emails:
+        email = valid_emails[0]
+    else:
+        raise errors.VerifyExistsException("No Valid Emails found") # Wrong Exception, suggest alternate?
+    
+    
     already_verified = session.execute(select(VerifiedEmails).filter_by(email=email)).scalar()
 
     to_reverify = session.execute(select(ToReVerify).filter_by(u_id=user_id)).all()


### PR DESCRIPTION
## Summary
When a user verifies with the bot they are prompted to provide an email address to verify they belong to the domain the bot has been set up with.
The bot detects if the domain is present, but does not filter out multiple emails. It is possible to 'inject' your own random email followed by a comma and a fake institutional email to gain access to any server.

I have tried to be as unintrusive as possible with a fix, but do not have the ability to test these changes. Please note this adds the requirement for regular expressions.

## Checklist
<!-- Put an x inside [ ] to check it, like this: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)

<br>

- [ ] Have you tested the changes? ([pytest](https://docs.pytest.org/) & [dpytest](https://dpytest.readthedocs.io/))
- [x] Have you followed [PEP-8](https://www.python.org/dev/peps/pep-0008/) for naming and styling?  
- [ ] Has your code been properly documented with RestructuredText docstrings?
- [ ] Have you added your changes to `CHANGELOG.md` under the `[Unreleased]` heading?
- [ ] If your code added new bot commands, have you updated `documentation.json`?

<br>

- [x] All of this code is your own, or follows the author repo's licence.
